### PR TITLE
feat(angular-prod-env): add api versioning to endpoint urls

### DIFF
--- a/ui/src/environments/environment.defaults.ts
+++ b/ui/src/environments/environment.defaults.ts
@@ -1,30 +1,40 @@
-export const environment = {
-  usersUrl: '/users',
-  groupsUrl: '/groups',
-  membersUrl: '/members',
-  usersVersionUrl: '/version',
-  loginUrl: '/tokens',
-  requestPassUrl: '/password/reset-request',
-  resetPassUrl: '/password/reset',
-  changePassUrl: '/password',
-  thingsUrl: '/things',
-  twinsUrl: '/twins',
-  statesUrl: '/states',
-  channelsUrl: '/channels',
-  bootstrapConfigsUrl: '/bootstrap/things/configs',
-  bootstrapUrl: '/bootstrap/things/bootstrap',
-  connectUrl: '/connect',
-  browseUrl: '/browse',
-
-  // ORB
-  sinksUrl: '/sinks',
-
-  httpAdapterUrl: '/http',
-  readerUrl: '/reader',
-  readerPrefix: 'channels',
-  readerSuffix: 'messages',
-
-
-  mqttWsUrl: window['env']['mqttWsUrl'] || 'ws://localhost/mqtt',
-  exportConfigFile: '/configs/export/config.toml',
+const ORB = {
+  // introduce primitive ORB api versioning '/api/v1/sinks'
+  orbApi: {
+    version: '1', // ORB api version
+    apiUrl: '/api/v', // ORB api url prefix
+  },
+  servicesUrls: {
+    sinksUrl: '/sinks',
+    agentsUrl: '/agents',
+    agentGroupsUrl: '/agent_groups',
+  },
 };
+export const environment = {
+    usersUrl: '/users',
+    groupsUrl: '/groups',
+    membersUrl: '/members',
+    usersVersionUrl: '/version',
+    loginUrl: '/tokens',
+    requestPassUrl: '/password/reset-request',
+    resetPassUrl: '/password/reset',
+    changePassUrl: '/password',
+    thingsUrl: '/things',
+    twinsUrl: '/twins',
+    statesUrl: '/states',
+    channelsUrl: '/channels',
+    bootstrapConfigsUrl: '/bootstrap/things/configs',
+    bootstrapUrl: '/bootstrap/things/bootstrap',
+    connectUrl: '/connect',
+    browseUrl: '/browse',
+    httpAdapterUrl: '/http',
+    readerUrl: '/reader',
+    readerPrefix: 'channels',
+    readerSuffix: 'messages',
+    mqttWsUrl: window['env']['mqttWsUrl'] || 'ws://localhost/mqtt',
+    exportConfigFile: '/configs/export/config.toml',
+    // expose ORB routes and api versioning
+    orbApi: ORB.orbApi,
+    ...ORB.servicesUrls,
+  }
+;

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -1,7 +1,14 @@
 import { environment as defaultEnvironment } from './environment.defaults';
 
+const {sinksUrl, agentsUrl, agentGroupsUrl, orbApi: {apiUrl, version}} = defaultEnvironment;
+
 export const environment = {
   production: true,
 
-    ...defaultEnvironment,
+  ...defaultEnvironment,
+  // ORB api --prod
+  // override all urls prepend /api/v<#>/<service_url>
+  sinksUrl: `${apiUrl}${version}${sinksUrl}`,
+  agentsUrl: `${apiUrl}${version}${agentsUrl}`,
+  agentGroupsUrl: `${apiUrl}${version}${agentGroupsUrl}`,
 };


### PR DESCRIPTION
Set up different endpoint urls based on --prod or default builds,
prepending orb defined endpoints url with *<api_url_prefix><version_number>*

eg.: `sinksUrl: '/sinks'` -> `sinksUrl: '/api/v1/sinks'`

closes #86 