### PR TITLE
feat(ORB-69): Sink Creation Page

### DIFF
--- a/ui/src/app/common/interfaces/orb/sink.config/prometheus.config.interface.ts
+++ b/ui/src/app/common/interfaces/orb/sink.config/prometheus.config.interface.ts
@@ -4,7 +4,9 @@
  * /src/cmd/prom-sink/main.go
  * https://github.com/ns1labs/orb/wiki/Architecture:-Sinks
  */
-export interface Prometheus {
+import { SinkConfig } from 'app/common/interfaces/orb/sink.config/sink.config.interface';
+
+export interface PrometheusConfig extends SinkConfig<string> {
   /** Remote Host Name: string */
   remote_host?: string;
   /** Username: string */

--- a/ui/src/app/common/interfaces/orb/sink.config/sink.config.interface.ts
+++ b/ui/src/app/common/interfaces/orb/sink.config/sink.config.interface.ts
@@ -1,0 +1,8 @@
+/**
+ * Base Sink Config Interface
+ * for more details:
+ * https://github.com/ns1labs/orb/wiki/Architecture:-Sinks
+ */
+export interface SinkConfig<T> {
+  [propName: string]: T;
+}

--- a/ui/src/app/common/interfaces/orb/sink.interface.ts
+++ b/ui/src/app/common/interfaces/orb/sink.interface.ts
@@ -4,7 +4,8 @@
  * https://github.com/ns1labs/orb/wiki/Architecture:-Sinks
  */
 
-import { Prometheus } from 'app/common/interfaces/prometheus.interface';
+import { PrometheusConfig } from 'app/common/interfaces/orb/sink.config/prometheus.config.interface';
+import { SinkConfig } from 'app/common/interfaces/orb/sink.config/sink.config.interface';
 
 export interface Sink {
   /** id: UUIDv4 (read only) */
@@ -17,7 +18,7 @@ export interface Sink {
    * ORB Tags: orb_tags string<JSON>
    * simple key/values - no recursive objects
    */
-  tags?: any;
+  tags?: { [propName: string]: string };
   /** Status: string ['active'|'error'] */
   status?: string;
   /** Error Message: string contains error message if status is 'error' (read only) */
@@ -29,7 +30,7 @@ export interface Sink {
    */
   backend?: string;
   /** config: object containing sink specific info */
-  config?: { remote_host?: string, username?: string } | any;
+  config?: SinkConfig<string>;
   /** ts_created: UUIDv4 (read only) */
   ts_created?: string;
 }
@@ -38,5 +39,14 @@ export interface Sink {
  * Prometheus Sink Type
  */
 export type PromSink = Sink | {
-  config?: Prometheus;
+  config?: PrometheusConfig;
 };
+
+/**
+ * for future
+ * Sink<T> = {..., config?: <T>, ...}
+ * or
+ * SpecificSink = Sink | {//{[overrides: string]: any};
+ * or
+ * SpecificSink extends PrometheusConfig;
+ */

--- a/ui/src/app/common/interfaces/prometheus.interface.ts
+++ b/ui/src/app/common/interfaces/prometheus.interface.ts
@@ -1,0 +1,14 @@
+/**
+ * Prometheus Sink Config Interface
+ * for more details:
+ * /src/cmd/prom-sink/main.go
+ * https://github.com/ns1labs/orb/wiki/Architecture:-Sinks
+ */
+export interface Prometheus {
+  /** Remote Host Name: string */
+  remote_host?: string;
+  /** Username: string */
+  username?: string;
+  /** Password: string */
+  password?: string;
+}

--- a/ui/src/app/common/interfaces/sink.interface.ts
+++ b/ui/src/app/common/interfaces/sink.interface.ts
@@ -1,14 +1,47 @@
+/**
+ * Sink Data Model Interface
+ *
+ * https://github.com/ns1labs/orb/wiki/Architecture:-Sinks
+ */
+
+import { Prometheus } from 'app/common/interfaces/prometheus.interface';
+
+export enum sinkStatus {
+  active = 'active',
+  error = 'error',
+}
+
 export interface Sink {
+  /** id: UUIDv4 (read only) */
   id?: string;
+  /** Name: string [a-zA-Z_:][a-zA-Z0-9_]* */
   name?: string;
+  /** Description: string */
   description?: string;
+  /**
+   * ORB Tags: orb_tags string<JSON>
+   * simple key/values - no recursive objects
+   */
   tags?: any;
-  status?: string;
+  /** Status: string ['active'|'error'] */
+  status?: sinkStatus | string;
+  /** Error Message: string contains error message if status is 'error' (read only) */
   error?: string;
+  /**
+   * Backend Type: string (set once)
+   * Match a backend from /features/sinks.
+   * Cannot change once created (read only)
+   */
   backend?: string;
-  config?: {
-    remote_host: string;
-    username: string;
-  };
+  /** config: object containing sink specific info */
+  config?: { remote_host?: string, username?: string } | any;
+  /** ts_created: UUIDv4 (read only) */
   ts_created?: string;
 }
+
+/**
+ * Prometheus Sink Type
+ */
+export type PromSink = Sink | {
+  config?: Prometheus;
+};

--- a/ui/src/app/common/interfaces/sink.interface.ts
+++ b/ui/src/app/common/interfaces/sink.interface.ts
@@ -6,11 +6,6 @@
 
 import { Prometheus } from 'app/common/interfaces/prometheus.interface';
 
-export enum sinkStatus {
-  active = 'active',
-  error = 'error',
-}
-
 export interface Sink {
   /** id: UUIDv4 (read only) */
   id?: string;
@@ -24,7 +19,7 @@ export interface Sink {
    */
   tags?: any;
   /** Status: string ['active'|'error'] */
-  status?: sinkStatus | string;
+  status?: string;
   /** Error Message: string contains error message if status is 'error' (read only) */
   error?: string;
   /**

--- a/ui/src/app/common/services/sinks/sinks.service.ts
+++ b/ui/src/app/common/services/sinks/sinks.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import 'rxjs/add/observable/empty';
 
 import { environment } from 'environments/environment';
-import { Sink } from 'app/common/interfaces/sink.interface';
+import { Sink } from 'app/common/interfaces/orb/sink.interface';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 import { PageFilters } from 'app/common/interfaces/mainflux.interface';
 

--- a/ui/src/app/pages/pages-routing.module.ts
+++ b/ui/src/app/pages/pages-routing.module.ts
@@ -48,14 +48,16 @@ const children = environment.production ?
     {
       path: 'sinks',
       component: SinksComponent,
-    },
-    {
-      path: 'sinks/add',
-      component: SinksAddComponent,
-    },
-    {
-      path: 'sinks/edit/:id',
-      component: SinksAddComponent,
+      children: [
+        {
+          path: 'add',
+          component: SinksAddComponent,
+        },
+        {
+          path: 'edit/:id',
+          component: SinksAddComponent,
+        },
+      ],
     },
   ] : [
     {
@@ -86,14 +88,16 @@ const children = environment.production ?
     {
       path: 'sinks',
       component: SinksComponent,
-    },
-    {
-      path: 'sinks/add',
-      component: SinksAddComponent,
-    },
-    {
-      path: 'sinks/edit/:id',
-      component: SinksAddComponent,
+      children: [
+        {
+          path: 'add',
+          component: SinksAddComponent,
+        },
+        {
+          path: 'edit/:id',
+          component: SinksAddComponent,
+        },
+      ],
     },
   ];
 

--- a/ui/src/app/pages/pages-routing.module.ts
+++ b/ui/src/app/pages/pages-routing.module.ts
@@ -48,16 +48,14 @@ const children = environment.production ?
     {
       path: 'sinks',
       component: SinksComponent,
-      children: [
-        {
-          path: 'add',
-          component: SinksAddComponent,
-        },
-        {
-          path: 'edit/:id',
-          component: SinksAddComponent,
-        },
-      ],
+    },
+    {
+      path: 'sinks/add',
+      component: SinksAddComponent,
+    },
+    {
+      path: 'sinks/edit',
+      component: SinksAddComponent,
     },
   ] : [
     {
@@ -88,16 +86,14 @@ const children = environment.production ?
     {
       path: 'sinks',
       component: SinksComponent,
-      children: [
-        {
-          path: 'add',
-          component: SinksAddComponent,
-        },
-        {
-          path: 'edit/:id',
-          component: SinksAddComponent,
-        },
-      ],
+    },
+    {
+      path: 'sinks/add',
+      component: SinksAddComponent,
+    },
+    {
+      path: 'sinks/edit',
+      component: SinksAddComponent,
     },
   ];
 

--- a/ui/src/app/pages/pages.module.ts
+++ b/ui/src/app/pages/pages.module.ts
@@ -22,12 +22,11 @@ import { FormsModule } from '@angular/forms';
 import { SharedModule } from 'app/shared/shared.module';
 import { CommonModule } from 'app/common/common.module';
 import { ConfirmationComponent } from 'app/shared/components/confirmation/confirmation.component';
-// ORB SPECIFIC
-// ORB - dataset-explorer
+
+// ORB
 import { DatasetsComponent } from 'app/pages/datasets/datasets.component';
 import { DatasetsAddComponent } from 'app/pages/datasets/add/datasets.add.component';
 import { DatasetsDetailsComponent } from 'app/pages/datasets/details/datasets.details.component';
-// ORB - fleet-management
 import { FleetsComponent } from 'app/pages/fleets/fleets.component';
 import { FleetsAddComponent } from 'app/pages/fleets/add/fleets.add.component';
 import { FleetsDetailsComponent } from 'app/pages/fleets/details/fleets.details.component';

--- a/ui/src/app/pages/pages.module.ts
+++ b/ui/src/app/pages/pages.module.ts
@@ -17,7 +17,7 @@ import { DashboardModule } from './dashboard/dashboard.module';
 import { PagesRoutingModule } from './pages-routing.module';
 
 // Mainflux - Dependencies
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 // Mainflux - Common and Shared
 import { SharedModule } from 'app/shared/shared.module';
 import { CommonModule } from 'app/common/common.module';
@@ -37,6 +37,9 @@ import { SinksDeleteComponent } from 'app/pages/sinks/delete/sinks.delete.compon
 import { AgentsComponent } from 'app/pages/agents/agents.component';
 import { AgentsAddComponent } from 'app/pages/agents/add/agents.add.component';
 import { AgentsDetailsComponent } from 'app/pages/agents/details/agents.details.component';
+import { MatInputModule } from '@angular/material/input';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatIconModule } from '@angular/material/icon';
 
 @NgModule({
   imports: [
@@ -54,6 +57,10 @@ import { AgentsDetailsComponent } from 'app/pages/agents/details/agents.details.
     NbCheckboxModule,
     NbListModule,
     NbTabsetModule,
+    ReactiveFormsModule,
+    MatInputModule,
+    MatChipsModule,
+    MatIconModule,
   ],
   exports: [
     SharedModule,

--- a/ui/src/app/pages/sinks/add/sinks.add.component.html
+++ b/ui/src/app/pages/sinks/add/sinks.add.component.html
@@ -1,12 +1,11 @@
-<!-- TODO refactor this into page<variable fields> + stepper -->
-<nb-card>
-  <nb-card-header class="table-header">
-    New Sink
-  </nb-card-header>
-  <nb-card-body>
+<div>
+  <header>
+    <div>{{strings[action].header}}</div>
+  </header>
+  <div>
     <div class="row form-row">
       <div class="col-3 form-key">
-        Name<span class="ns1red">*</span>
+        {{strings.propNames.name}}<span class="ns1red">*</span>
       </div>
       <div class="col-6">
         <input nbInput fullWidth fieldSize="tiny"
@@ -15,7 +14,7 @@
     </div>
     <div class="row form-row">
       <div class="col-3 form-key">
-        Description
+        {{strings.propNames.description}}
       </div>
       <div class="col-6">
         <input nbInput fullWidth fieldSize="tiny"
@@ -24,7 +23,7 @@
     </div>
     <div class="row form-row">
       <div class="col-3 form-key">
-        Tags
+        {{strings.propNames.tags}}
       </div>
       <div class="col-6">
         <input nbInput fullWidth fieldSize="tiny"
@@ -33,7 +32,7 @@
     </div>
     <div class="row form-row">
       <div class="col-3 form-key">
-        Type<span class="ns1red">*</span>
+        {{strings.propNames.backend}}<span class="ns1red">*</span>
       </div>
       <div class="col-6">
         <input nbInput fullWidth fieldSize="tiny"
@@ -42,7 +41,7 @@
     </div>
     <div class="row form-row">
       <div class="col-3 form-key">
-        Remote Host<span class="ns1red">*</span>
+        {{strings.propNames.config_remote_host}}<span class="ns1red">*</span>
       </div>
       <div class="col-6">
         <input nbInput fullWidth fieldSize="tiny"
@@ -51,17 +50,17 @@
     </div>
     <div class="row form-row">
       <div class="col-3 form-key">
-        Username
+        {{strings.propNames.config_username}}
       </div>
       <div class="col-6">
         <input nbInput fullWidth fieldSize="tiny"
                [(ngModel)]='formData.config.username'>
       </div>
     </div>
-  </nb-card-body>
+  </div>
 
-  <nb-card-footer>
-    <button nbButton status="success" (click)="submit()">Accept</button>
-    <button nbButton status="danger" (click)="cancel()">Cancel</button>
-  </nb-card-footer>
-</nb-card>
+  <footer>
+    <button nbButton status="success" (click)="submit()">{{strings.stepper.save}}</button>
+    <button nbButton status="danger" (click)="cancel()">{{strings.stepper.back}}</button>
+  </footer>
+</div>

--- a/ui/src/app/pages/sinks/add/sinks.add.component.html
+++ b/ui/src/app/pages/sinks/add/sinks.add.component.html
@@ -1,7 +1,7 @@
 <!-- TODO refactor this into page<variable fields> + stepper -->
 <nb-card>
   <nb-card-header class="table-header">
-    {{ this.action }} New Sink
+    New Sink
   </nb-card-header>
   <nb-card-body>
     <div class="row form-row">
@@ -61,7 +61,7 @@
   </nb-card-body>
 
   <nb-card-footer>
-    <button nbButton status="success" (click)="submit()">{{this.action}}</button>
+    <button nbButton status="success" (click)="submit()">Accept</button>
     <button nbButton status="danger" (click)="cancel()">Cancel</button>
   </nb-card-footer>
 </nb-card>

--- a/ui/src/app/pages/sinks/add/sinks.add.component.html
+++ b/ui/src/app/pages/sinks/add/sinks.add.component.html
@@ -1,66 +1,75 @@
 <div>
   <header>
-    <div>{{strings[action].header}}</div>
+    <div>{{strings.sink[isEdit ? 'edit' : 'add']['header']}}</div>
   </header>
   <div>
-    <div class="row form-row">
-      <div class="col-3 form-key">
-        {{strings.propNames.name}}<span class="ns1red">*</span>
-      </div>
-      <div class="col-6">
-        <input nbInput fullWidth fieldSize="tiny"
-               [(ngModel)]='formData.name'>
-      </div>
+    <div>
+      <p>
+        {{strings.sink.propNames.name}}<span class="ns1red">*</span>
+      </p>
+      <input nbInput id="name" type="text" [(ngModel)]="sink.name">
     </div>
-    <div class="row form-row">
-      <div class="col-3 form-key">
-        {{strings.propNames.description}}
-      </div>
-      <div class="col-6">
-        <input nbInput fullWidth fieldSize="tiny"
-               [(ngModel)]='formData.description'>
-      </div>
+    <div>
+      <p>
+        {{strings.sink.propNames.description}}
+      </p>
+      <input nbInput id="description" type="text" [(ngModel)]="sink.description">
     </div>
-    <div class="row form-row">
-      <div class="col-3 form-key">
-        {{strings.propNames.tags}}
-      </div>
-      <div class="col-6">
-        <input nbInput fullWidth fieldSize="tiny"
-               [(ngModel)]='formData.tags'>
-      </div>
+    <div>
+      <p>
+        {{strings.sink.propNames.backend}}<span class="ns1red">*</span>
+      </p>
+      <input nbInput [placeholder]="sinkTypesList.prometheus" id='backend' type=text [(ngModel)]="sink.backend">
     </div>
-    <div class="row form-row">
-      <div class="col-3 form-key">
-        {{strings.propNames.backend}}<span class="ns1red">*</span>
-      </div>
-      <div class="col-6">
-        <input nbInput fullWidth fieldSize="tiny"
-               [(ngModel)]='formData.backend'>
-      </div>
+    <div>
+      <p>
+        {{strings.sink.propNames.config_remote_host}}<span class="ns1red">*</span>
+      </p>
+      <input nbInput id='config.remote_host' type=text [(ngModel)]='sink.config.remote_host'>
     </div>
-    <div class="row form-row">
-      <div class="col-3 form-key">
-        {{strings.propNames.config_remote_host}}<span class="ns1red">*</span>
-      </div>
-      <div class="col-6">
-        <input nbInput fullWidth fieldSize="tiny"
-               [(ngModel)]='formData.config.remote_host'>
-      </div>
+    <div>
+      <p>
+        {{strings.sink.propNames.config_username}}
+      </p>
+      <input nbInput id='config.username' type=text [(ngModel)]='sink.config.username'>
     </div>
-    <div class="row form-row">
-      <div class="col-3 form-key">
-        {{strings.propNames.config_username}}
-      </div>
-      <div class="col-6">
-        <input nbInput fullWidth fieldSize="tiny"
-               [(ngModel)]='formData.config.username'>
+    <div>
+      <p>
+        {{strings.sink.propNames.tags}}
+      </p>
+      <div>
+        <!--TODO tags add/edit/delete actions and view components.
+         * create a component for tag add action
+         * create a component that shows a tag and has a delete button
+         *  always display fresh tags.add.component, when user clicks addNewTag(),
+         push tag details into sink|sinkForm to update displayed tag list and reset
+         tag input fields. 
+        -->
+        <mat-form-field appearance="fill">
+          <mat-chip-list>
+            <mat-chip *ngFor="let tag of ((sink?.tags || {}) | tagsArrayPipe)"
+                      selectable removable (removed)="removeTag(tag)">
+              <span>&#123;</span>
+              {{tag.key}}
+              <span>: </span>
+              {{tag.value}}
+              <span>&#125;</span>
+              <nb-icon icon="close-circle-outline" matChipRemove>cancel</nb-icon>
+            </mat-chip>
+          </mat-chip-list>
+        </mat-form-field>
+        <div>
+          <input [(ngModel)]="tagsForm.key" nbInput placeholder="{{strings.tags.key}}">
+          <span>:</span>
+          <input [(ngModel)]="tagsForm.value" nbInput placeholder="{{strings.tags.value}}">
+          <button nbButton status="success" (click)="addTag()">{{strings.tags.addTag}}</button>
+        </div>
       </div>
     </div>
   </div>
 
   <footer>
-    <button nbButton status="success" (click)="submit()">{{strings.stepper.save}}</button>
+    <button nbButton status="success" (click)="onSubmit()">{{strings.stepper.save}}</button>
     <button nbButton status="danger" (click)="cancel()">{{strings.stepper.back}}</button>
   </footer>
 </div>

--- a/ui/src/app/pages/sinks/add/sinks.add.component.ts
+++ b/ui/src/app/pages/sinks/add/sinks.add.component.ts
@@ -5,6 +5,7 @@ import { SinksService } from 'app/common/services/sinks/sinks.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Sink } from 'app/common/interfaces/sink.interface';
 import { STRINGS } from 'assets/text/strings';
+import { sinkTypes } from 'app/pages/sinks/sinks.component';
 
 @Component({
   selector: 'ngx-sinks-add-component',

--- a/ui/src/app/pages/sinks/add/sinks.add.component.ts
+++ b/ui/src/app/pages/sinks/add/sinks.add.component.ts
@@ -3,6 +3,8 @@ import { Component, Input } from '@angular/core';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 import { SinksService } from 'app/common/services/sinks/sinks.service';
 import { ActivatedRoute, Router } from '@angular/router';
+import { Sink } from 'app/common/interfaces/sink.interface';
+import { STRINGS } from 'assets/text/strings';
 
 @Component({
   selector: 'ngx-sinks-add-component',
@@ -10,9 +12,13 @@ import { ActivatedRoute, Router } from '@angular/router';
   styleUrls: ['./sinks.add.component.scss'],
 })
 export class SinksAddComponent {
-  editorMetadata = '';
 
-  @Input() formData = {
+  strings = STRINGS.sink;
+
+  action = '';
+
+  @Input()
+  formData = {
     name: '',
     description: '',
     tags: '',
@@ -24,12 +30,18 @@ export class SinksAddComponent {
     metadata: {},
   };
 
+  sink: Sink;
+  isEdit: boolean;
+
   constructor(
     private sinksService: SinksService,
     private notificationsService: NotificationsService,
     private router: Router,
     private route: ActivatedRoute,
   ) {
+    this.sink = this.router.getCurrentNavigation().extras.state?.sink || null;
+    this.isEdit = !!this.sink;
+    this.action = this.isEdit ? 'edit' : 'add';
   }
 
   goBack() {

--- a/ui/src/app/pages/sinks/add/sinks.add.component.ts
+++ b/ui/src/app/pages/sinks/add/sinks.add.component.ts
@@ -1,8 +1,8 @@
 import { Component, Input } from '@angular/core';
-import { NbDialogRef } from '@nebular/theme';
 
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 import { SinksService } from 'app/common/services/sinks/sinks.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'ngx-sinks-add-component',
@@ -23,20 +23,25 @@ export class SinksAddComponent {
     },
     metadata: {},
   };
-  @Input() action: string = '';
 
   constructor(
-    protected dialogRef: NbDialogRef<SinksAddComponent>,
     private sinksService: SinksService,
     private notificationsService: NotificationsService,
+    private router: Router,
   ) {
   }
 
+  goBack() {
+    this.router.navigate([`${this.router.getCurrentNavigation()}`]);
+  }
+
   cancel() {
-    this.dialogRef.close(false);
+    this.goBack();
   }
 
   submit() {
+    const action = this.router.routerState.snapshot.url.split('/').pop().toLowerCase();
+
     if (this.formData.tags !== '') {
       try {
         this.formData.tags = JSON.parse(this.formData.tags);
@@ -47,19 +52,19 @@ export class SinksAddComponent {
     }
 
     this.formData.backend && (this.formData.metadata['backend'] = this.formData.backend);
-    if (this.action === 'Add') {
+    if (action === 'add') {
       this.sinksService.addSink(this.formData).subscribe(
         resp => {
           this.notificationsService.success('Sink successfully created', '');
-          this.dialogRef.close(true);
+          this.goBack();
         },
       );
     }
-    if (this.action === 'Edit') {
+    if (action === 'edit') {
       this.sinksService.editSink(this.formData).subscribe(
         resp => {
           this.notificationsService.success('Sink successfully edited', '');
-          this.dialogRef.close(true);
+          this.goBack();
         },
       );
     }

--- a/ui/src/app/pages/sinks/add/sinks.add.component.ts
+++ b/ui/src/app/pages/sinks/add/sinks.add.component.ts
@@ -2,7 +2,7 @@ import { Component, Input } from '@angular/core';
 
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 import { SinksService } from 'app/common/services/sinks/sinks.service';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'ngx-sinks-add-component',
@@ -28,11 +28,12 @@ export class SinksAddComponent {
     private sinksService: SinksService,
     private notificationsService: NotificationsService,
     private router: Router,
+    private route: ActivatedRoute,
   ) {
   }
 
   goBack() {
-    this.router.navigate([`${this.router.getCurrentNavigation()}`]);
+    this.router.navigate(['../../sinks'], {relativeTo: this.route});
   }
 
   cancel() {
@@ -56,6 +57,11 @@ export class SinksAddComponent {
       this.sinksService.addSink(this.formData).subscribe(
         resp => {
           this.notificationsService.success('Sink successfully created', '');
+        },
+        error => {
+          this.notificationsService.error('Sink creation failed', error);
+        },
+        () => {
           this.goBack();
         },
       );
@@ -63,7 +69,12 @@ export class SinksAddComponent {
     if (action === 'edit') {
       this.sinksService.editSink(this.formData).subscribe(
         resp => {
-          this.notificationsService.success('Sink successfully edited', '');
+          this.notificationsService.success('Sink successfully updated', '');
+        },
+        error => {
+          this.notificationsService.error('Sink update failed', error);
+        },
+        () => {
           this.goBack();
         },
       );

--- a/ui/src/app/pages/sinks/add/sinks.add.component.ts
+++ b/ui/src/app/pages/sinks/add/sinks.add.component.ts
@@ -1,11 +1,11 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 import { SinksService } from 'app/common/services/sinks/sinks.service';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Sink } from 'app/common/interfaces/sink.interface';
+import { Sink } from 'app/common/interfaces/orb/sink.interface';
 import { STRINGS } from 'assets/text/strings';
-import { sinkTypes } from 'app/pages/sinks/sinks.component';
+import { sinkTypesList } from 'app/pages/sinks/sinks.component';
 
 @Component({
   selector: 'ngx-sinks-add-component',
@@ -14,24 +14,26 @@ import { sinkTypes } from 'app/pages/sinks/sinks.component';
 })
 export class SinksAddComponent {
 
-  strings = STRINGS.sink;
+  strings = STRINGS;
 
-  action = '';
-
-  @Input()
-  formData = {
+  sinkForm = {
     name: '',
     description: '',
-    tags: '',
-    backend: '',
+    backend: sinkTypesList.prometheus,
     config: {
-      remote_host: '',
+      host_name: '',
       username: '',
+      password: '',
     },
-    metadata: {},
+    tags: {},
   };
+  
+  tagsForm = { key: '', value: '' };
 
   sink: Sink;
+
+  sinkTypesList = sinkTypesList;
+
   isEdit: boolean;
 
   constructor(
@@ -40,34 +42,28 @@ export class SinksAddComponent {
     private router: Router,
     private route: ActivatedRoute,
   ) {
-    this.sink = this.router.getCurrentNavigation().extras.state?.sink || null;
+    this.sink = this.router.getCurrentNavigation().extras.state?.sink as Sink || null;
     this.isEdit = !!this.sink;
-    this.action = this.isEdit ? 'edit' : 'add';
+    if (!this.isEdit) {
+      this.sink = this.emptySink();
+    }
   }
 
   goBack() {
-    this.router.navigate(['../../sinks'], {relativeTo: this.route});
+    this.sink &&
+    this.router.navigate(['../../sinks'], { relativeTo: this.route });
   }
 
   cancel() {
     this.goBack();
   }
 
-  submit() {
-    const action = this.router.routerState.snapshot.url.split('/').pop().toLowerCase();
+  onSubmit() {
+    const { name, description, backend, tags, config } = this.sinkForm;
 
-    if (this.formData.tags !== '') {
-      try {
-        this.formData.tags = JSON.parse(this.formData.tags);
-      } catch (e) {
-        this.notificationsService.error('Wrong metadata format', '');
-        return;
-      }
-    }
-
-    this.formData.backend && (this.formData.metadata['backend'] = this.formData.backend);
-    if (action === 'add') {
-      this.sinksService.addSink(this.formData).subscribe(
+    // Create Sink State
+    if (!this.isEdit) {
+      this.sinksService.addSink(this.sink).subscribe(
         resp => {
           this.notificationsService.success('Sink successfully created', '');
         },
@@ -79,8 +75,9 @@ export class SinksAddComponent {
         },
       );
     }
-    if (action === 'edit') {
-      this.sinksService.editSink(this.formData).subscribe(
+    // Edit Sink State
+    if (this.isEdit) {
+      this.sinksService.editSink(this.sink).subscribe(
         resp => {
           this.notificationsService.success('Sink successfully updated', '');
         },
@@ -92,5 +89,41 @@ export class SinksAddComponent {
         },
       );
     }
+  }
+
+  addTag() {
+    const { key, value } = this.tagsForm;
+
+    // TODO check if all keys need a value or there could
+    // be something like 'key': '' <empty string>
+    // TODO check if tags are overridable without warning
+    if (!this.sink.tags[key]) {
+      this.sink.tags = { ...this.sink.tags, ...{ [key]: value } };
+      // TODO add create tag confirmation snack/toaster
+    } else {
+      // TODO add tag already exists snack/toaster
+    }
+  }
+
+  removeTag(tag) {
+    delete this.sink.tags[tag];
+    // TODO add delete tag confirmation snack/toaster
+  }
+
+  /**
+   * Utility: returns empty-initialized sink object
+   * @return <Sink> <Sink>{[propName::Sink]: '' | {[propName::SinkConfig|any]: any}};
+   */
+  emptySink()
+    :
+    Sink {
+    return <Sink>{
+      name: '',
+      description: '',
+      // TODO initialize backend as ''
+      backend: sinkTypesList.prometheus,
+      config: { remote_host: '', username: '', password: '' },
+      tags: {},
+    };
   }
 }

--- a/ui/src/app/pages/sinks/details/sinks.details.component.ts
+++ b/ui/src/app/pages/sinks/details/sinks.details.component.ts
@@ -1,8 +1,8 @@
-import {Component, Input} from '@angular/core';
-import {NbDialogRef} from '@nebular/theme';
-import {STRINGS} from 'assets/text/strings';
+import { Component, Input } from '@angular/core';
+import { NbDialogRef } from '@nebular/theme';
+import { STRINGS } from 'assets/text/strings';
 
-const strings = STRINGS.sink.details;
+const strings = STRINGS.sink;
 
 @Component({
   selector: 'ngx-sinks-details-component',
@@ -10,13 +10,13 @@ const strings = STRINGS.sink.details;
   styleUrls: ['./sinks.details.component.scss'],
 })
 export class SinksDetailsComponent {
-  header: string = strings.header;
-  close: string = strings.close;
-  name: string = strings.name;
-  description: string = strings.description;
-  backend: string = strings.backend;
-  remote_host: string = strings.remote_host;
-  ts_created: string = strings.ts_created;
+  header = strings.details.header;
+  close = strings.details.close;
+  name = strings.propNames.name;
+  description = strings.propNames.description;
+  backend = strings.propNames.backend;
+  remote_host = strings.propNames.config_remote_host;
+  ts_created = strings.propNames.ts_created;
 
   @Input() sink = {
     id: '',
@@ -38,7 +38,6 @@ export class SinksDetailsComponent {
 
   onOpenEdit(row: any) {
     // TODO implement router call
-    console.error('sink edit unavailable');
   }
 
   onClose() {

--- a/ui/src/app/pages/sinks/details/sinks.details.component.ts
+++ b/ui/src/app/pages/sinks/details/sinks.details.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { NbDialogRef } from '@nebular/theme';
 import { STRINGS } from 'assets/text/strings';
+import { ActivatedRoute, Router } from '@angular/router';
 
 const strings = STRINGS.sink;
 
@@ -31,13 +32,19 @@ export class SinksDetailsComponent {
   };
 
   constructor(
-      protected dialogRef: NbDialogRef<SinksDetailsComponent>,
+    protected dialogRef: NbDialogRef<SinksDetailsComponent>,
+    protected route: ActivatedRoute,
+    protected router: Router,
   ) {
   }
 
 
   onOpenEdit(row: any) {
-    // TODO implement router call
+    this.router.navigate(['../sinks/edit'], {
+      relativeTo: this.route,
+      queryParams: {id: row.id},
+      state: {sink: row},
+    });
   }
 
   onClose() {

--- a/ui/src/app/pages/sinks/sinks.component.html
+++ b/ui/src/app/pages/sinks/sinks.component.html
@@ -18,7 +18,7 @@
     <ngx-table-component (addEvent)=onOpenAdd()
                          (delEvent)=openDeleteModal($event)
                          (detailsEvent)=openDetailsModal($event)
-                         (editEvent)=onOpenEdit()
+                         (editEvent)=onOpenEdit($event)
                          [config]="tableConfig"
                          [page]="page">
     </ngx-table-component>

--- a/ui/src/app/pages/sinks/sinks.component.ts
+++ b/ui/src/app/pages/sinks/sinks.component.ts
@@ -16,6 +16,21 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 const defFreq: number = 100;
 
+/**
+ * Available sink statuses
+ */
+export enum sinkStatus {
+  active = 'active',
+  error = 'error',
+}
+
+export enum sinkTypes {
+  prometheus = 'prometheus',
+  // aws = 'aws',
+  // s3 = 's3',
+  // azure = 'azure',
+}
+
 @Component({
   selector: 'ngx-sinks-component',
   templateUrl: './sinks.component.html',

--- a/ui/src/app/pages/sinks/sinks.component.ts
+++ b/ui/src/app/pages/sinks/sinks.component.ts
@@ -12,7 +12,7 @@ import { NotificationsService } from 'app/common/services/notifications/notifica
 import { SinksService } from 'app/common/services/sinks/sinks.service';
 import { SinksDetailsComponent } from 'app/pages/sinks/details/sinks.details.component';
 import { SinksDeleteComponent } from 'app/pages/sinks/delete/sinks.delete.component';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 const defFreq: number = 100;
 
@@ -22,19 +22,23 @@ const defFreq: number = 100;
   styleUrls: ['./sinks.component.scss'],
 })
 export class SinksComponent implements OnInit {
+
   tableConfig: TableConfig = {
     colNames: ['Name', 'Description', 'Type', 'Status', 'Tags', 'orb-sink-add'],
     keys: ['name', 'description', 'type', 'status', 'tags', 'orb-action-hover'],
   };
+
   page: TablePage = {
     limit: 10,
   };
+
   pageFilters: PageFilters = {
     offset: 0,
     order: 'id',
     dir: 'desc',
     name: '',
   };
+
   tableFilters: DropdownFilterItem[];
 
   searchFreq = 0;
@@ -44,6 +48,7 @@ export class SinksComponent implements OnInit {
     private sinkService: SinksService,
     private notificationsService: NotificationsService,
     private router: Router,
+    private route: ActivatedRoute,
   ) {
     this.tableFilters = this.tableConfig.colNames.map((name, index) => ({
       id: index.toString(),
@@ -88,7 +93,7 @@ export class SinksComponent implements OnInit {
   }
 
   onOpenAdd() {
-    this.router.navigate([`${this.router.routerState.snapshot.url}/add`]);
+    this.router.navigate(['./add'], {relativeTo: this.route});
   }
 
   onOpenEdit() {

--- a/ui/src/app/pages/sinks/sinks.component.ts
+++ b/ui/src/app/pages/sinks/sinks.component.ts
@@ -47,8 +47,8 @@ export class SinksComponent implements OnInit {
     private dialogService: NbDialogService,
     private sinkService: SinksService,
     private notificationsService: NotificationsService,
-    private router: Router,
     private route: ActivatedRoute,
+    private router: Router,
   ) {
     this.tableFilters = this.tableConfig.colNames.map((name, index) => ({
       id: index.toString(),
@@ -93,13 +93,13 @@ export class SinksComponent implements OnInit {
   }
 
   onOpenAdd() {
-    this.router.navigate(['add'], {
+    this.router.navigate(['../sinks/add'], {
       relativeTo: this.route,
     });
   }
 
   onOpenEdit(row: any) {
-    this.router.navigate(['edit'], {
+    this.router.navigate(['../sinks/edit'], {
       relativeTo: this.route,
       queryParams: {id: row.id},
       state: {sink: row},

--- a/ui/src/app/pages/sinks/sinks.component.ts
+++ b/ui/src/app/pages/sinks/sinks.component.ts
@@ -10,9 +10,9 @@ import {
 } from 'app/common/interfaces/mainflux.interface';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 import { SinksService } from 'app/common/services/sinks/sinks.service';
-import { SinksAddComponent } from 'app/pages/sinks/add/sinks.add.component';
 import { SinksDetailsComponent } from 'app/pages/sinks/details/sinks.details.component';
 import { SinksDeleteComponent } from 'app/pages/sinks/delete/sinks.delete.component';
+import { Router } from '@angular/router';
 
 const defFreq: number = 100;
 
@@ -43,6 +43,7 @@ export class SinksComponent implements OnInit {
     private dialogService: NbDialogService,
     private sinkService: SinksService,
     private notificationsService: NotificationsService,
+    private router: Router,
   ) {
     this.tableFilters = this.tableConfig.colNames.map((name, index) => ({
       id: index.toString(),
@@ -87,13 +88,7 @@ export class SinksComponent implements OnInit {
   }
 
   onOpenAdd() {
-    this.dialogService.open(SinksAddComponent, {context: {action: 'Add'}}).onClose.subscribe(
-      confirm => {
-        if (confirm) {
-          this.getSinks();
-        }
-      },
-    );
+    this.router.navigate([`${this.router.routerState.snapshot.url}/add`]);
   }
 
   onOpenEdit() {

--- a/ui/src/app/pages/sinks/sinks.component.ts
+++ b/ui/src/app/pages/sinks/sinks.component.ts
@@ -93,17 +93,17 @@ export class SinksComponent implements OnInit {
   }
 
   onOpenAdd() {
-    this.router.navigate(['./add'], {relativeTo: this.route});
+    this.router.navigate(['add'], {
+      relativeTo: this.route,
+    });
   }
 
-  onOpenEdit() {
-    // this.dialogService.open(SinksAddComponent, {context: {action: 'Edit'}}).onClose.subscribe(
-    //   confirm => {
-    //     if (confirm) {
-    //       this.getSinks();
-    //     }
-    //   },
-    // );
+  onOpenEdit(row: any) {
+    this.router.navigate(['edit'], {
+      relativeTo: this.route,
+      queryParams: {id: row.id},
+      state: {sink: row},
+    });
   }
 
   openDeleteModal(row: any) {

--- a/ui/src/app/pages/sinks/sinks.component.ts
+++ b/ui/src/app/pages/sinks/sinks.component.ts
@@ -24,7 +24,7 @@ export enum sinkStatus {
   error = 'error',
 }
 
-export enum sinkTypes {
+export enum sinkTypesList {
   prometheus = 'prometheus',
   // aws = 'aws',
   // s3 = 's3',

--- a/ui/src/app/shared/components/table/table.component.html
+++ b/ui/src/app/shared/components/table/table.component.html
@@ -2,9 +2,11 @@
   <tr>
     <th *ngFor="let colName of config.colNames">
       <div [ngSwitch]="colName">
+        <!-- TODO create some sort of rule to detect when to use different cases here-->
+        <!-- TODO generalize this table component and introduce strings from `STRINGS{}` -->
         <button *ngSwitchCase="'orb-sink-add'" nbButton ghost=true class="button-new-sink"
                 (click)="onAdd()">
-          + New Sink
+          {{strings.sink.list.create}}
         </button>
         <div *ngSwitchDefault>
           {{ colName }}

--- a/ui/src/app/shared/components/table/table.component.ts
+++ b/ui/src/app/shared/components/table/table.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 import { TableConfig, TablePage } from 'app/common/interfaces/mainflux.interface';
+import { STRINGS } from 'assets/text/strings';
 
 @Component({
   selector: 'ngx-table-component',
@@ -9,6 +10,8 @@ import { TableConfig, TablePage } from 'app/common/interfaces/mainflux.interface
 })
 export class TableComponent {
   isHover: boolean;
+
+  strings = STRINGS;
 
   isObject(val: any): boolean {
     return typeof val === 'object';

--- a/ui/src/app/shared/pipes/tags-array.pipe.ts
+++ b/ui/src/app/shared/pipes/tags-array.pipe.ts
@@ -1,0 +1,9 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+// Convert from seconds to milliseconds
+@Pipe({ name: 'tagsArrayPipe' })
+export class TagsArrayPipe implements PipeTransform {
+  transform(tags: { [propName: string]: string }): Array<{ key: string, value: string }> {
+    return Object.keys(tags).map(tagKey => ({ key: `${tagKey}`, value: `${tags[tagKey]}` }));
+  }
+}

--- a/ui/src/app/shared/shared.module.ts
+++ b/ui/src/app/shared/shared.module.ts
@@ -22,6 +22,7 @@ import { MessageValuePipe } from './pipes/message-value.pipe';
 import { ToMillisecsPipe } from './pipes/time.pipe';
 import { TableComponent } from './components/table/table.component';
 import { PaginationComponent } from './components/pagination/pagination.component';
+import { TagsArrayPipe } from 'app/shared/pipes/tags-array.pipe';
 
 @NgModule({
   imports: [
@@ -44,6 +45,7 @@ import { PaginationComponent } from './components/pagination/pagination.componen
     MessageMonitorComponent,
     MessageValuePipe,
     ToMillisecsPipe,
+    TagsArrayPipe,
     TableComponent,
     PaginationComponent,
   ],
@@ -57,10 +59,12 @@ import { PaginationComponent } from './components/pagination/pagination.componen
     MessageMonitorComponent,
     TableComponent,
     PaginationComponent,
+    TagsArrayPipe,
   ],
   providers: [
     MessageValuePipe,
     ToMillisecsPipe,
+    TagsArrayPipe,
   ],
 })
 

--- a/ui/src/assets/text/strings.ts
+++ b/ui/src/assets/text/strings.ts
@@ -14,6 +14,11 @@ export const STRINGS = {
   },
   // Sink Pages strings
   sink: {
+    // sink statuses
+    status: {
+      active: 'Active',
+      error: 'Error',
+    },
     // sink.interface name descriptors
     propNames: {
       id: 'id',

--- a/ui/src/assets/text/strings.ts
+++ b/ui/src/assets/text/strings.ts
@@ -31,6 +31,7 @@ export const STRINGS = {
       config: 'Connection Details',
       config_remote_host: 'Remote Host',
       config_username: 'Username',
+      config_password: 'Password',
       ts_created: 'Date Created',
     },
     // add page

--- a/ui/src/assets/text/strings.ts
+++ b/ui/src/assets/text/strings.ts
@@ -11,8 +11,31 @@ export const STRINGS = {
   fleet: {
     title: 'Fleet Management',
   },
+  // Sink Pages strings
   sink: {
-    header: 'All Sinks',
+    // sink.interface name descriptors
+    propNames: {
+      id: 'id',
+      name: 'Name',
+      description: 'Description',
+      tags: 'Tags',
+      status: 'Status',
+      error: 'Error',
+      backend: 'Service Type',
+      config: 'Connection Details',
+      config_remote_host: 'Remote Host',
+      config_username: 'Username',
+      ts_created: 'Date Created',
+    },
+    // add page
+    add: {
+      header: 'Create New Sink',
+    },
+    // edit page
+    edit: {
+      header: 'Update Sink',
+    },
+    // delete modal
     delete: {
       header: 'Delete Sink Confirmation',
       body: 'Are you sure you want to delete this sink? This may cause policies which use this sink to become invalid. This action cannot be undone.',
@@ -22,11 +45,29 @@ export const STRINGS = {
     details: {
       header: 'Sink Details',
       close: 'Close',
-      name: 'Sink Name',
-      description: 'Sink Description',
-      backend: 'Sink Service Type',
-      remote_host: 'Remote Host',
-      ts_created: 'Date Created',
+    },
+    // dashboard page
+    list: {
+      header: 'All Sinks',
+      none: 'There are no sinks listed.',
+      sink: 'sink',
+      total: ['You have', 'total.'],
+      error: 'have errors.',
+      create: 'New Sink',
+      filters: {
+        select: 'Filter',
+        name: 'Name',
+        description: 'Description',
+        status: 'Status',
+        type: 'Type',
+        tags: 'Tags',
+      },
+    },
+    // stepper cues
+    stepper: {
+      back: 'Back',
+      next: 'Next',
+      save: 'Save',
     },
   },
 };

--- a/ui/src/assets/text/strings.ts
+++ b/ui/src/assets/text/strings.ts
@@ -8,6 +8,7 @@ export const STRINGS = {
   home: {
     title: 'Orb Observation Overview',
   },
+  // Fleet Pages strings
   fleet: {
     title: 'Fleet Management',
   },
@@ -42,6 +43,7 @@ export const STRINGS = {
       warning: '*To confirm, type your sink label exactly as it appears',
       close: 'Close',
     },
+    // details modal
     details: {
       header: 'Sink Details',
       close: 'Close',

--- a/ui/src/assets/text/strings.ts
+++ b/ui/src/assets/text/strings.ts
@@ -71,11 +71,17 @@ export const STRINGS = {
         tags: 'Tags',
       },
     },
-    // stepper cues
-    stepper: {
-      back: 'Back',
-      next: 'Next',
-      save: 'Save',
-    },
+  },
+  // stepper cues
+  stepper: {
+    back: 'Back',
+    next: 'Next',
+    save: 'Save',
+  },
+  // tags cues
+  tags: {
+    addTag: 'Add New Tag',
+    key: 'Tag Key',
+    value: 'Tag Value',
   },
 };


### PR DESCRIPTION
* inject router to sinks.add.component
* change <create sink> button to route to sinks.add.component
* add notifications for success|failure upon creation
* modal to page conversion
* use strings from STRINGS definition
* sinks.add.component able to support add and edit

* TODO route not working
* TODO dynamic fields from service type
* TODO prefill input fields when editing

closes #69
advance work in #51 by making sinks.add.component reusable
advance work in #65 removing unused css rules