### PR TITLE
feat(orb-ui orb-tests): Add data-* attr to automated testing

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -1,61 +1,51 @@
-# ORB<a href="https://github.com/akveo/nebular">Nebular</a>
+# <a href="https://github.com/ns1labs/orb">Orb</a> UI
 
-## Prerequisites
+> This wiki is targeted at developers looking to build the UI from source, to either
+> run it locally for development purposes or to create a custom UI docker image.
+
+## Development
+
+### Prerequisites
 
 The following are needed to run the UI:
 
-- [Docker](https://docs.docker.com/install/) (version 20.10)
-- [Docker compose](https://docs.docker.com/compose/install/) (version 1.28)
+* [node](https://nodejs.org/en/blog/release/v12.21.0/)
+* [npm](https://github.com/npm/cli/tree/v7.22.0)
 
-## Install
-For a quick setup, pre-built images from Docker Hub can be used.
+*It is recomended to build the UI using [yarn](https://www.npmjs.com/package/yarn)*
 
-First, make sure that `docker` and `docker-compose` are installed. Also, stop existing Mainflux containers if any.
+### Install
 
-Then, use the following instructions:
 ```bash
-git clone https://github.com/mainflux/ui.git
-cd ui
-make run
+# note: if you haven't checked out the full repo yet, and you're only interested in developing 
+# the front end locally, you can do so by checking out only the ui folder.
+# [read more...](
+git clone git@github.com:ns1labs/orb.git --no-checkout --depth 1 ${path}
+
+# however you clone the project
+cd ${path}/ui
+yarn install
 ```
-UI should be now up and running at `http://localhost/`.
 
-*(Note that `http://localhost:3000/` is for internal use only, and is not intended to be used by the end-user.)*
+### Usage
 
-More configuration (port numbers, etc.) can be done by editing the `.env` file before `make run`.
-
-## Usage
 A developer build from the source can be achieved using the following command:
+
 ```bash
-make ui
-```
-Then, to start the Mainflux UI as well as other Mainflux services:
-```bash
-make run
-```
-For more developer tools, run `angular-cli`:
-```bash
-cd ui
-npm install
-npm start
-```
-## Uninstall
-To remove the installed containers and volumes, run:
-```bash
-make clean
+yarn build
 ```
 
-## Preview
+*(Check [package.json](./package.json) file for available tasks.)*
 
-##
-![dashboard][dashboard]
+While developing, it is useful to serve UI locally and have your changes to the code having effect immediately.
 
-##
-![things][things]
+The commands `yarn start` and `yarn start:withmock` will generate a dev build and serve it at `http://localhost:4200/`.
 
-##
-![details][details]
+*(Note that `http://localhost:4200/` is for development use only, and is not intended to be used by the end-user.)*
 
-[dashboard]: https://github.com/mainflux/docs/blob/master/docs/img/ui/dashboard.png
-[things]: https://github.com/mainflux/docs/blob/master/docs/img/ui/things.png
-[details]: https://github.com/mainflux/docs/blob/master/docs/img/ui/details.png
+*([proxy-config.json](./proxy-config.json) re-routes all outbound requests when running local serve task)
+
+## QA & Testing
+
+Quality Assurance & Test frameworks and scripts are still a *WORK IN PROGRESS*  
+Check our [Wiki](https://github.com/ns1labs/orb/wiki/UI-QA-Automation-Tags) for more information.

--- a/ui/src/app/pages/sinks/add/sink.add.component.html
+++ b/ui/src/app/pages/sinks/add/sink.add.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-  <header>
+  <header data-orb-qa-id="@sink#add">
     <xng-breadcrumb class="orb-breadcrumb">
       <ng-container
           *xngBreadcrumbItem="let breadcrumb; let info = info; let first = first">
@@ -14,13 +14,14 @@
                   class="stepper w-100 ml-5"
                   disableStepNavigation>
         <nb-step [label]="firstStepTemplate"
-                 [stepControl]="firstFormGroup">
-           <ng-template #firstStepTemplate>
-                <div class="step-label d-flex flex-column">
-                  <strong>Sink Details</strong>
-                  <p>Provide a name and description for the Sink</p>
-                </div>
-            </ng-template>
+                 [stepControl]="firstFormGroup"
+                 data-orb-qa-id="@sink#add.step_1">
+          <ng-template #firstStepTemplate>
+            <div class="step-label d-flex flex-column">
+              <strong>Sink Details</strong>
+              <p>Provide a name and description for the Sink</p>
+            </div>
+          </ng-template>
           <form [formGroup]="firstFormGroup" (ngSubmit)="onFormSubmit()">
             <nb-form-field>
               <div class="d-flex flex-column">
@@ -76,39 +77,42 @@
                       shape="round"
                       status="primary"
                       type="submit"
-                      [disabled]="!firstFormGroup?.valid" nbStepperNext>Next</button>
+                      [disabled]="!firstFormGroup?.valid" nbStepperNext>Next
+              </button>
             </div>
           </form>
         </nb-step>
-        <nb-step [label]="secondStepLabel">
-            <ng-template #secondStepLabel>
-                <div class="step-label d-flex flex-column">
-                  <strong>Sink Destination</strong>
-                  <p>Configure your sink settings</p>
-                </div>
-            </ng-template>
+        <nb-step [label]="secondStepLabel"
+                 data-orb-qa-id="@sink#add.step_2">
+          <ng-template #secondStepLabel>
+            <div class="step-label d-flex flex-column">
+              <strong>Sink Destination</strong>
+              <p>Configure your sink settings</p>
+            </div>
+          </ng-template>
           <form [formGroup]="secondFormGroup">
             <nb-form-field *ngFor="let control of selectedSinkSetting;let i = index">
               <div>
                 <label class="font-weight-bold">{{control.label}}</label>
               </div>
               <div [ngSwitch]="control.input">
-                 <input *ngSwitchCase="'text'"
-                   [autofocus]="i == 0"
-                   nbInput
-                   [type]="control.type"
-                   fullWidth="true"
-                   fieldSize="medium"
-                   [formControlName]="control.prop" />
-               <nb-select *ngSwitchCase="'select'"
-                          appearance="filled"
-                          size="medium"
-                          fullWidth="true"
-                          formControlName="backend"
-                          placeholder="Select backend type">
-                <nb-option *ngFor="let type of control.options"
-                           [value]="type">{{ type }}</nb-option>
-               </nb-select>
+                <input *ngSwitchCase="'text'"
+                       [autofocus]="i == 0"
+                       nbInput
+                       [type]="control.type"
+                       fullWidth="true"
+                       fieldSize="medium"
+                       [formControlName]="control.prop"
+                       data-orb-qa-id="sink.type.select">/>
+                <nb-select *ngSwitchCase="'select'"
+                           appearance="filled"
+                           size="medium"
+                           fullWidth="true"
+                           formControlName="backend"
+                           placeholder="Select backend type">
+                  <nb-option *ngFor="let type of control.options"
+                             [value]="type">{{ type }}</nb-option>
+                </nb-select>
               </div>
               <hr/>
             </nb-form-field>
@@ -129,7 +133,8 @@
             </div>
           </form>
         </nb-step>
-        <nb-step [label]="thirdStepLabel">
+        <nb-step [label]="thirdStepLabel"
+                 data-orb-qa-id="@sink#add.step_3">
           <ng-template #thirdStepLabel>
             <div class="step-label d-flex flex-column">
               <strong>Sink Tags</strong>
@@ -221,7 +226,8 @@
             </div>
           </form>
         </nb-step>
-        <nb-step [label]="fourthStepLabel">
+        <nb-step [label]="fourthStepLabel"
+                 data-orb-qa-id="@sink#add.step_4">
           <ng-template #fourthStepLabel>
             <div class="step-label d-flex flex-column">
               <strong>Review & Confirm</strong>
@@ -262,7 +268,8 @@
             <mat-chip-list>
               <mat-chip
                   class="orb-tag-sink "
-                  *ngFor="let tag of thirdFormGroup.controls.tags.value">
+                  *ngFor="let tag of thirdFormGroup.controls.tags.value; index as i;"
+                  [attr.data-orb-qa-id]="'tag_' + i">
                 {{ tag | keyvalue | tagchip}}
               </mat-chip>
             </mat-chip-list>
@@ -272,14 +279,16 @@
                 nbButton
                 ghost
                 status="primary"
-                nbStepperPrevious>Back
+                nbStepperPrevious
+                data-orb-qa-id="@sink#add.stepper.previous">Back
             </button>
             <button class="next-button"
                     nbButton
                     shape="round"
                     status="primary"
                     (click)="onFormSubmit()"
-                    type="submit">Save
+                    type="submit"
+                    data-orb-qa-id="@sink#add.stepper.next">Save
             </button>
           </div>
         </nb-step>

--- a/ui/src/app/pages/sinks/add/sink.add.component.html
+++ b/ui/src/app/pages/sinks/add/sink.add.component.html
@@ -1,6 +1,7 @@
 <div class="container">
-  <header data-orb-qa-id="@sink#add">
-    <xng-breadcrumb class="orb-breadcrumb">
+  <header data-orb-qa-id="sink#add">
+    <xng-breadcrumb class="orb-breadcrumb"
+                    data-orb-qa-id="breadcrumb">
       <ng-container
           *xngBreadcrumbItem="let breadcrumb; let info = info; let first = first">
         <ng-container [ngClass]="{'my_class': first === ''}">{{ breadcrumb }}</ng-container>
@@ -15,7 +16,7 @@
                   disableStepNavigation>
         <nb-step [label]="firstStepTemplate"
                  [stepControl]="firstFormGroup"
-                 data-orb-qa-id="@sink#add.step_1">
+                 data-orb-qa-id="step_1">
           <ng-template #firstStepTemplate>
             <div class="step-label d-flex flex-column">
               <strong>Sink Details</strong>
@@ -33,7 +34,8 @@
                        autofocus
                        fullWidth="true"
                        fieldSize="medium"
-                       formControlName="name"/>
+                       formControlName="name"
+                       data-orb-qa-id="name"/>
               </div>
             </nb-form-field>
             <hr/>
@@ -44,7 +46,8 @@
               <input nbInput
                      fullWidth="true"
                      fieldSize="medium"
-                     formControlName="description"/>
+                     formControlName="description"
+                     data-orb-qa-id="description"/>
             </nb-form-field>
             <hr/>
             <nb-form-field>
@@ -58,6 +61,7 @@
                          formControlName="backend"
                          appearance="filled"
                          placeholder="Select backend type"
+                         data-orb-qa-id="backend"
               >
                 <nb-option *ngFor="let type of sinkTypesList"
                            [value]="type">{{ type | titlecase }}</nb-option>
@@ -70,20 +74,23 @@
                   ghost
                   (click)="goBack()"
                   type="button"
-                  status="primary">Cancel
+                  status="primary"
+                  data-orb-qa-id="cancel">Cancel
               </button>
               <button class="next-button"
                       nbButton
                       shape="round"
                       status="primary"
                       type="submit"
-                      [disabled]="!firstFormGroup?.valid" nbStepperNext>Next
+                      [disabled]="!firstFormGroup?.valid"
+                      nbStepperNext
+                      data-orb-qa-id="next">Next
               </button>
             </div>
           </form>
         </nb-step>
         <nb-step [label]="secondStepLabel"
-                 data-orb-qa-id="@sink#add.step_2">
+                 data-orb-qa-id="step_2">
           <ng-template #secondStepLabel>
             <div class="step-label d-flex flex-column">
               <strong>Sink Destination</strong>
@@ -103,13 +110,14 @@
                        fullWidth="true"
                        fieldSize="medium"
                        [formControlName]="control.prop"
-                       data-orb-qa-id="sink.type.select">/>
+                       [attr.data-orb-qa-id]="control.prop">
                 <nb-select *ngSwitchCase="'select'"
                            appearance="filled"
                            size="medium"
                            fullWidth="true"
                            formControlName="backend"
-                           placeholder="Select backend type">
+                           placeholder="Select backend type"
+                           data-orb-qa-id="backend">
                   <nb-option *ngFor="let type of control.options"
                              [value]="type">{{ type }}</nb-option>
                 </nb-select>
@@ -121,20 +129,24 @@
                   nbButton
                   ghost
                   status="primary"
-                  nbStepperPrevious>Back
+                  nbStepperPrevious
+                  data-orb-qa-id="cancel"
+              >Back
               </button>
               <button class="next-button"
                       nbButton
                       shape="round"
                       status="primary"
                       type="submit"
-                      [disabled]="!secondFormGroup?.valid" nbStepperNext>Next
+                      [disabled]="!secondFormGroup?.valid"
+                      nbStepperNext
+                      data-orb-qa-id="next">Next
               </button>
             </div>
           </form>
         </nb-step>
         <nb-step [label]="thirdStepLabel"
-                 data-orb-qa-id="@sink#add.step_3">
+                 data-orb-qa-id="step_3">
           <ng-template #thirdStepLabel>
             <div class="step-label d-flex flex-column">
               <strong>Sink Tags</strong>
@@ -143,10 +155,11 @@
           </ng-template>
           <form [formGroup]="thirdFormGroup">
             <div class="d-flex">
-              <mat-chip-list>
+              <mat-chip-list data-orb-qa-id="tagList">
                 <mat-chip
                     class="orb-tag-sink "
-                    *ngFor="let tag of thirdFormGroup.controls.tags.value">
+                    *ngFor="let tag of thirdFormGroup.controls.tags.value; index as i"
+                    [attr.data-orb-qa-id]="'tag_' + i">
                   {{ tag | keyvalue | tagchip}}
                   <nb-icon style="color: #ffffff; margin-left: 4px;"
                            status="primary"
@@ -169,7 +182,8 @@
                            autofocus
                            fullWidth="true"
                            fieldSize="medium"
-                           formControlName="key"/>
+                           formControlName="key"
+                           data-orb-qa-id="key"/>
                   </div>
                 </div>
                 <div class="d-flex justify-content-center align-items-center col-1 mt-4 px-0 mx-0">
@@ -185,7 +199,8 @@
                            autofocus
                            fullWidth="true"
                            fieldSize="medium"
-                           formControlName="value"/>
+                           formControlName="value"
+                           data-orb-qa-id="value"/>
                   </div>
                 </div>
                 <div class="d-flex col-1 align-items-center justify-content-center mx-0 pl-4 px-0"
@@ -194,7 +209,8 @@
                           ghost
                           (click)="onAddTag()"
                           [disabled]="(thirdFormGroup.controls['key'].value === '' ||
-                          thirdFormGroup.controls['value'].value === '')">
+                          thirdFormGroup.controls['value'].value === '')"
+                          data-orb-qa-id="addTag">
                     <nb-icon style="color: #df316f;"
                              status="primary"
                              icon="plus-outline"
@@ -212,7 +228,8 @@
                   nbButton
                   ghost
                   status="primary"
-                  nbStepperPrevious>
+                  nbStepperPrevious
+                  data-orb-qa-id="back">
                 {{strings.stepper.back}}
               </button>
               <button class="next-button"
@@ -220,14 +237,16 @@
                       shape="round"
                       status="primary"
                       type="submit"
-                      [disabled]="!secondFormGroup.valid" nbStepperNext>
+                      [disabled]="!secondFormGroup.valid"
+                      nbStepperNext
+                      data-orb-qa-id="next">
                 {{strings.stepper.next}}
               </button>
             </div>
           </form>
         </nb-step>
         <nb-step [label]="fourthStepLabel"
-                 data-orb-qa-id="@sink#add.step_4">
+                 data-orb-qa-id="step_4">
           <ng-template #fourthStepLabel>
             <div class="step-label d-flex flex-column">
               <strong>Review & Confirm</strong>
@@ -237,19 +256,19 @@
             <div class="col-md-12 col-xl-6">
               <div>
                 <label class="font-weight-bold">Name Label</label>
-                <p>{{firstFormGroup?.controls.name.value}}</p>
+                <p data-orb-qa-id="review-name">{{firstFormGroup?.controls.name.value}}</p>
               </div>
             </div>
-            <div class="col-md-12 col-xl-6">
+            <div class="col-md-12 col-xl-6">has
               <div>
                 <label class="font-weight-bold">Description</label>
-                <p>{{firstFormGroup?.controls.description.value}}</p>
+                <p data-orb-qa-id="review-description">{{firstFormGroup?.controls.description.value}}</p>
               </div>
             </div>
             <div class="col-md-12 col-xl-6">
               <div>
                 <label class="font-weight-bold">Sink Type</label>
-                <p>{{firstFormGroup?.controls.backend.value}}</p>
+                <p data-orb-qa-id="review-backend">{{firstFormGroup?.controls.backend.value}}</p>
               </div>
             </div>
           </div>
@@ -258,18 +277,20 @@
             <div class="col-md-12 col-xl-6" *ngFor="let control of selectedSinkSetting">
               <div>
                 <label class="font-weight-bold">{{control.label}}</label>
-                <p *ngIf="control.type != 'password'">{{secondFormGroup.controls[control.prop].value}}</p>
-                <p *ngIf="control.type == 'password'">*******</p>
+                <p *ngIf="control.type != 'password'"
+                   [attr.data-orb-qa-id]="'review-' + control.prop">{{secondFormGroup.controls[control.prop].value}}</p>
+                <p *ngIf="control.type == 'password'"
+                   [attr.data-orb-qa-id]="'review-' + control.prop">*******</p>
               </div>
             </div>
           </div>
           <hr/>
           <div class="d-flex">
-            <mat-chip-list>
+            <mat-chip-list data-orb-qaid="review-tagList">
               <mat-chip
                   class="orb-tag-sink "
                   *ngFor="let tag of thirdFormGroup.controls.tags.value; index as i;"
-                  [attr.data-orb-qa-id]="'tag_' + i">
+                  [attr.data-orb-qa-id]="'review-tag_' + i">
                 {{ tag | keyvalue | tagchip}}
               </mat-chip>
             </mat-chip-list>
@@ -280,7 +301,7 @@
                 ghost
                 status="primary"
                 nbStepperPrevious
-                data-orb-qa-id="@sink#add.stepper.previous">Back
+                data-orb-qa-id="previous">Back
             </button>
             <button class="next-button"
                     nbButton
@@ -288,7 +309,7 @@
                     status="primary"
                     (click)="onFormSubmit()"
                     type="submit"
-                    data-orb-qa-id="@sink#add.stepper.next">Save
+                    data-orb-qa-id="next">Save
             </button>
           </div>
         </nb-step>


### PR DESCRIPTION
@manrodrigues I've completed the Sink Add Page with basic tag info and also updated the `README.md`.  

I've created a page with examples [](https://github.com/ns1labs/orb/wiki/UI-QA-Automation-Tags), but you can check further additions [here](https://github.com/ns1labs/orb/pull/222/files) :)  

*(This Pull Request is good to be merged, or the branch preserved until all pages have their respective automation tags.)*  

>Add data-orb-qa-id to some elements of `sink.add.component` for testing.

>@manrodrigues besides id for static and dynamic content, such as tables, is there any other type of metadata you could use?

>I've added just a few tags for you to test and give some feedback. There are a few links below for reference. :)

>https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*

>https://www.techiediaries.com/add-access-html-data-attribute-angular/

>https://angular.io/guide/template-syntax