### PR TITLE
feat(orb-ui orb-docker): Dockerfile update npm to yarn

### DIFF
--- a/ui/docker/Dockerfile
+++ b/ui/docker/Dockerfile
@@ -2,9 +2,12 @@
 FROM node:14.15.4 as node
 WORKDIR /app
 COPY package.json /app/
-RUN npm install
+# I'm not sure if yarn is available from this node it imported
+# but it could be installed with npm install -g yarn
+# RUN npm install -g yarn
+RUN yarn install
 COPY ./ /app/
-RUN npm run build:prod
+RUN yarn build:prod
 
 # Stage 1, based on Nginx, to have only the compiled app, ready for production with Nginx
 FROM nginx:1.13-alpine

--- a/ui/docker/Dockerfile
+++ b/ui/docker/Dockerfile
@@ -1,10 +1,7 @@
 # Stage 0, based on Node.js, to build and compile Angular
-FROM node:14.15.4 as node
+FROM node:12.21.0 as node
 WORKDIR /app
 COPY package.json /app/
-# I'm not sure if yarn is available from this node it imported
-# but it could be installed with npm install -g yarn
-# RUN npm install -g yarn
 RUN yarn install
 COPY ./ /app/
 RUN yarn build:prod


### PR DESCRIPTION
Update [Dockerfile](./ui/docker/Dockerfile) to use yarn instead of npm.
Yarn resolves peer deps and package conflicts with more ease.
Also quicker than update the giant package.json dep list RN.

Update Orb UI dockerfile commands