### PR TITLE
fix(orb-ui orb-agents): #220 fix agentGroup redirect 

### DIFF
--- a/ui/src/app/pages/fleet/groups/add/agent.group.add.component.ts
+++ b/ui/src/app/pages/fleet/groups/add/agent.group.add.component.ts
@@ -124,9 +124,9 @@ export class AgentGroupAddComponent implements OnInit, AfterViewInit {
 
   goBack() {
     if (this.isEdit) {
-      this.router.navigate(['../../../agent-groups'], {relativeTo: this.route});
+      this.router.navigate(['../../'], {relativeTo: this.route});
     } else {
-      this.router.navigate(['../../agent-groups'], {relativeTo: this.route});
+      this.router.navigate(['../'], {relativeTo: this.route});
     }
   }
 


### PR DESCRIPTION
Agent Group Create and Update pages routing to blank page.

Fix AgentGroup Create & Update pages redirect to blank page, either canceling or completing the process.

Closes #220 