### PR TITLE
fix(orb-ui orb-beta): fix bad overwritte in GTAG

### DIFF
--- a/ui/src/environments/environment.defaults.ts
+++ b/ui/src/environments/environment.defaults.ts
@@ -35,7 +35,6 @@ const ORB = {
 };
 
 export const environment = {
-  GTMID: 'GTM-K44NMJP',
   usersUrl: '/users',
   groupsUrl: '/groups',
   membersUrl: '/members',


### PR DESCRIPTION
Soon to be removed environment.prod.beta.ts GTMID property was being
overwritten by environment.ts late definition of GTMID.

Soon to be replaced with GTMID injection via node env.