### PR TITLE
fix(orb-ui): formControl name input validators

### DIFF
--- a/ui/src/app/pages/fleet/agents/add/agent.add.component.ts
+++ b/ui/src/app/pages/fleet/agents/add/agent.add.component.ts
@@ -42,7 +42,7 @@ export class AgentAddComponent {
   ) {
     this.agentLocation = '';
     this.firstFormGroup = this._formBuilder.group({
-      name: ['', Validators.required, Validators.pattern('[a-zA-Z_:][a-zA-Z0-9_]*')],
+      name: ['', [Validators.required, Validators.pattern('^[a-zA-Z_:][a-zA-Z0-9_]*$')]],
       location: [this.agentLocation, Validators.required],
     });
 

--- a/ui/src/app/pages/fleet/agents/add/agent.add.component.ts
+++ b/ui/src/app/pages/fleet/agents/add/agent.add.component.ts
@@ -42,7 +42,7 @@ export class AgentAddComponent {
   ) {
     this.agentLocation = '';
     this.firstFormGroup = this._formBuilder.group({
-      name: ['', Validators.required],
+      name: ['', Validators.required, Validators.pattern('[a-zA-Z_:][a-zA-Z0-9_]*')],
       location: [this.agentLocation, Validators.required],
     });
 

--- a/ui/src/app/pages/fleet/groups/add/agent.group.add.component.ts
+++ b/ui/src/app/pages/fleet/groups/add/agent.group.add.component.ts
@@ -86,7 +86,7 @@ export class AgentGroupAddComponent implements OnInit, AfterViewInit {
       tags: {},
     } as AgentGroup;
     this.firstFormGroup = this._formBuilder.group({
-      name: [name, Validators.required],
+      name: [name, Validators.required, Validators.pattern('[a-zA-Z_:][a-zA-Z0-9_]*')],
       description: [description],
     });
 

--- a/ui/src/app/pages/fleet/groups/add/agent.group.add.component.ts
+++ b/ui/src/app/pages/fleet/groups/add/agent.group.add.component.ts
@@ -86,7 +86,7 @@ export class AgentGroupAddComponent implements OnInit, AfterViewInit {
       tags: {},
     } as AgentGroup;
     this.firstFormGroup = this._formBuilder.group({
-      name: [name, Validators.required, Validators.pattern('[a-zA-Z_:][a-zA-Z0-9_]*')],
+      name: [name, [Validators.required, Validators.pattern('^[a-zA-Z_:][a-zA-Z0-9_]*$')]],
       description: [description],
     });
 

--- a/ui/src/app/pages/sinks/add/sink.add.component.ts
+++ b/ui/src/app/pages/sinks/add/sink.add.component.ts
@@ -81,7 +81,7 @@ export class SinkAddComponent {
         tags: {},
       } as Sink;
       this.firstFormGroup = this._formBuilder.group({
-        name: [name, Validators.required, Validators.pattern('[a-zA-Z_:][a-zA-Z0-9_]*')],
+        name: [name, [Validators.required, Validators.pattern('^[a-zA-Z_:][a-zA-Z0-9_]*$')]],
         description: [description],
         backend: [backend, Validators.required],
       });

--- a/ui/src/app/pages/sinks/add/sink.add.component.ts
+++ b/ui/src/app/pages/sinks/add/sink.add.component.ts
@@ -81,7 +81,7 @@ export class SinkAddComponent {
         tags: {},
       } as Sink;
       this.firstFormGroup = this._formBuilder.group({
-        name: [name, Validators.required],
+        name: [name, Validators.required, Validators.pattern('[a-zA-Z_:][a-zA-Z0-9_]*')],
         description: [description],
         backend: [backend, Validators.required],
       });


### PR DESCRIPTION
Add name input validators for `name` fields of `Agent`, `AgentGroup` and `Sink` Orb entities.