### PR TITLE
fix(orb-dockers): change mainflux version for docker builds

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -155,7 +155,7 @@ MF_SMTP_NOTIFIER_DB=subscriptions
 MF_SMTP_NOTIFIER_TEMPLATE=smtp-notifier.tmpl
 
 # Docker image tag
-MF_RELEASE_TAG=latest
+MF_RELEASE_TAG=0.12.1
 ORB_RELEASE_TAG=latest
 
 # Orb: fleet


### PR DESCRIPTION
change `MF_RELEASE_TAG=latest` to `MF_RELEASE_TAG=0.12.1`
fix orb system not booting up correctly