### PR TITLE
Hotfix/agents backends wrong url

### DIFF
--- a/fleet/api/http/endpoint_test.go
+++ b/fleet/api/http/endpoint_test.go
@@ -1288,7 +1288,7 @@ func TestAgentBackends(t *testing.T) {
 			req := testRequest{
 				client: cli.server.Client(),
 				method: http.MethodGet,
-				url:    fmt.Sprintf("%s/backends/agents", cli.server.URL),
+				url:    fmt.Sprintf("%s/agents/backends", cli.server.URL),
 				token:  tc.auth,
 			}
 			res, err := req.make()

--- a/fleet/api/http/transport.go
+++ b/fleet/api/http/transport.go
@@ -85,7 +85,7 @@ func MakeHandler(tracer opentracing.Tracer, svcName string, svc fleet.Service) h
 		decodeList,
 		types.EncodeResponse,
 		opts...))
-	r.Get("/backends/agents", kithttp.NewServer(
+	r.Get("/agents/backends", kithttp.NewServer(
 		kitot.TraceServer(tracer, "list_backends")(listAgentBackendsEndpoint(svc)),
 		decodeListBackends,
 		types.EncodeResponse,


### PR DESCRIPTION
Correct inverted url for agent backends
Resolves #429 