### PR TITLE
fix: #380 change copy icon after click

### DIFF
--- a/ui/src/app/pages/fleet/agents/key/agent.key.component.html
+++ b/ui/src/app/pages/fleet/agents/key/agent.key.component.html
@@ -15,7 +15,7 @@
     <p>Make sure to copy the Agent Key now. You won’t be able to see it again!</p>
 
     <label>Agent Key</label>
-    <pre><button [cdkCopyToClipboard]="key2copy" class="copy"><nb-icon icon="clipboard-outline" pack="eva" ></nb-icon></button><code>{{ agent?.key }}</code></pre>
+    <pre><button [cdkCopyToClipboard]="key2copy" class="copy"><nb-icon (click)="toggleIcon('key')" [icon]="copyKeyIcon" pack="eva" ></nb-icon></button><code>{{ agent?.key }}</code></pre>
     
     <label>Provisioning Command</label>
     <p>
@@ -28,7 +28,7 @@
       </a>
       for more advanced options.
     </p>
-    <pre><button [cdkCopyToClipboard]="command2copy" class="copy"><nb-icon icon="clipboard-outline" pack="eva"
+    <pre><button [cdkCopyToClipboard]="command2copy" class="copy"><nb-icon (click)="toggleIcon('command')" [icon]="copyCommandIcon" pack="eva"
     ></nb-icon></button><code>{{ command2show }}</code></pre>
   </nb-card-body>
 

--- a/ui/src/app/pages/fleet/agents/key/agent.key.component.ts
+++ b/ui/src/app/pages/fleet/agents/key/agent.key.component.ts
@@ -15,8 +15,10 @@ export class AgentKeyComponent implements OnInit {
   command2copy: string;
 
   command2show: string;
+  copyCommandIcon: string;
 
   key2copy: string;
+  copyKeyIcon: string;
 
   @Input() agent: Agent = {};
 
@@ -30,6 +32,8 @@ export class AgentKeyComponent implements OnInit {
   ngOnInit(): void {
     this.makeCommand2Copy();
     this.key2copy = this.agent.key;
+    this.copyCommandIcon = 'clipboard-outline';
+    this.copyKeyIcon = 'clipboard-outline';
   }
 
   makeCommand2Copy() {
@@ -48,6 +52,14 @@ ns1labs/orb-agent`;
 -e ORB_CLOUD_MQTT_KEY=${ this.agent.key } \n
 -e PKTVISOR_PCAP_IFACE_DEFAULT=mock \n
 ns1labs/orb-agent`;
+  }
+
+  toggleIcon (target) {
+    if (target === 'key') {
+      this.copyKeyIcon = 'checkmark-outline';
+    } else if (target === 'command') {
+      this.copyCommandIcon = 'checkmark-outline';
+    }
   }
 
   onClose() {


### PR DESCRIPTION
Closes #380 
@manrodrigues Instead of showing a message, the icon is changed after clicking and copy.