### PR TITLE
fix(orb-ui): #621 sink tags not required

### DIFF
--- a/ui/src/app/pages/sinks/add/sink.add.component.html
+++ b/ui/src/app/pages/sinks/add/sink.add.component.html
@@ -196,7 +196,6 @@
                 <div class="d-flex flex-column col-5 px-0 mx-0">
                   <div>
                     <label class="font-weight-bold">Key</label>
-                    <span class="required">*</span>
                   </div>
                   <div>
                     <input autofocus
@@ -213,7 +212,6 @@
                 <div class="d-flex flex-column col-5 px-0 mx-0">
                   <div>
                     <label class="font-weight-bold">Value</label>
-                    <span class="required">*</span>
                   </div>
                   <div>
                     <input autofocus

--- a/ui/src/app/pages/sinks/details/sink.details.component.html
+++ b/ui/src/app/pages/sinks/details/sink.details.component.html
@@ -38,7 +38,7 @@
     </div>
     <div class="row">
       <div class="col-6 d-flex flex-column align-items-start">
-        <p class="detail-title">{{strings.propNames.tags}}<span class="ns1red">*</span></p>
+        <p class="detail-title">{{strings.propNames.tags}}</p>
         <div>
           <mat-chip-list style="min-width: 0.2pc; min-height: 0.2pc;">
             <mat-chip


### PR DESCRIPTION
Remove red asterisk marking key/value pair and tag fields of sink as required.
#621 