### PR TITLE
fix(dataset): Fix http patch to put on edition.

### DIFF
--- a/policies/api/http/endpoint_test.go
+++ b/policies/api/http/endpoint_test.go
@@ -818,7 +818,7 @@ func TestDatasetEdition(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 			req := testRequest{
 				client:      cli.server.Client(),
-				method:      http.MethodPatch,
+				method:      http.MethodPut,
 				url:         fmt.Sprintf("%s/policies/dataset/%s", cli.server.URL, tc.id),
 				contentType: tc.contentType,
 				token:       tc.auth,

--- a/policies/api/http/transport.go
+++ b/policies/api/http/transport.go
@@ -79,7 +79,7 @@ func MakeHandler(tracer opentracing.Tracer, svcName string, svc policies.Service
 		decodeAddDatasetRequest,
 		types.EncodeResponse,
 		opts...))
-	r.Patch("/policies/dataset/:id", kithttp.NewServer(
+	r.Put("/policies/dataset/:id", kithttp.NewServer(
 		kitot.TraceServer(tracer, "edit_dataset")(editDatasetEndpoint(svc)),
 		decodeDatasetUpdate,
 		types.EncodeResponse,


### PR DESCRIPTION
Change the http verb on dataset edition
Using put and not patch to keep the project consistence 