### PR TITLE
feat(orb-ui): #640 display warning when no tags added for agent

### DIFF
--- a/ui/src/app/pages/fleet/agents/add/agent.add.component.html
+++ b/ui/src/app/pages/fleet/agents/add/agent.add.component.html
@@ -68,6 +68,7 @@
               <p>{{strings.add.step.desc2}}</p>
             </div>
           </ng-template>
+          <p *ngIf="(selectedTags | json) === '{}'">Agent tags were optional and may be set here or when you are provisioning an Agent.<br> The lack of tags will block an Agent to be matched during the Agent Group creation.</p>
           <form [formGroup]="secondFormGroup">
             <div class="d-flex">
               <mat-chip-list data-orb-qa-id="orb_tagsList">
@@ -84,7 +85,7 @@
                 </mat-chip>
                 <mat-chip
                   *ngIf="(selectedTags | json) === '{}'"
-                  [style.background-color]="'notaggit ' | tagcolor"
+                  [style.background-color]="'notag' | tagcolor"
                   class="orb-tag-sink ">
                   No tag added
                 </mat-chip>
@@ -191,7 +192,7 @@
                 </mat-chip>
                 <mat-chip
                   *ngIf="(selectedTags | json) === '{}'"
-                  [style.background-color]="'notaggit ' | tagcolor"
+                  [style.background-color]="'notag' | tagcolor"
                   class="orb-tag-sink ">
                   No tag added
                 </mat-chip>

--- a/ui/src/app/pages/fleet/agents/list/agent.list.component.html
+++ b/ui/src/app/pages/fleet/agents/list/agent.list.component.html
@@ -119,6 +119,12 @@
           [style.background-color]="tag | tagcolor">
         {{tag}}
       </mat-chip>
+      <mat-chip
+        *ngIf="(row.orb_tags | json) === '{}' && (row.agent_tags | json) === '{}'"
+        [style.background-color]="'notag' | tagcolor"
+        class="orb-tag-sink ">
+        No tags were created
+      </mat-chip>
     </mat-chip-list>
   </div>
 </ng-template>

--- a/ui/src/app/pages/sinks/add/sink.add.component.html
+++ b/ui/src/app/pages/sinks/add/sink.add.component.html
@@ -315,7 +315,7 @@
                 </mat-chip>
                 <mat-chip
                   *ngIf="(selectedTags | json) === '{}'"
-                  [style.background-color]="'notaggit ' | tagcolor"
+                  [style.background-color]="'notag' | tagcolor"
                   class="orb-tag-sink ">
                   No tag added
                 </mat-chip>


### PR DESCRIPTION
* Show message in agent add and agent list page warning user that agent has no tags to it.

* Also fix string for tag color on sink page