### PR TITLE
fix(orb-ui): #368 all required fields should have asterisk

### DIFF
--- a/ui/src/app/pages/datasets/policies.agent/add/agent.policy.add.component.html
+++ b/ui/src/app/pages/datasets/policies.agent/add/agent.policy.add.component.html
@@ -336,7 +336,7 @@
             <div *ngIf="!!liveHandler">
               <div>
                 <label class="font-weight-bold" for="description">Handler Label</label>
-                <span class="required"></span>
+                <span class="required">*</span>
               </div>
               <input class="col-10"
                      data-orb-qa-id="handler-label"


### PR DESCRIPTION
fix(orb-ui): add missing asterisk to handler label field