### PR TITLE
Bug/orb sinker ipv6 metrics

### DIFF
--- a/sinker/backend/pktvisor/pktvisor.go
+++ b/sinker/backend/pktvisor/pktvisor.go
@@ -142,19 +142,19 @@ func makePromParticle(ctxt *context, label string, k string, v interface{}, tsLi
 
 	var dpFlag dp
 	var labelsListFlag labelList
-	labelsListFlag.Set(fmt.Sprintf("__name__:%s", camelToSnake(label)))
-	labelsListFlag.Set("instance:" + ctxt.agent.AgentName)
-	labelsListFlag.Set("agent_id:" + ctxt.agentID)
-	labelsListFlag.Set("agent:" + ctxt.agent.AgentName)
-	labelsListFlag.Set("policy_id:" + ctxt.policyID)
-	labelsListFlag.Set("policy:" + ctxt.policyName)
+	labelsListFlag.Set(fmt.Sprintf("__name__;%s", camelToSnake(label)))
+	labelsListFlag.Set("instance;" + ctxt.agent.AgentName)
+	labelsListFlag.Set("agent_id;" + ctxt.agentID)
+	labelsListFlag.Set("agent;" + ctxt.agent.AgentName)
+	labelsListFlag.Set("policy_id;" + ctxt.policyID)
+	labelsListFlag.Set("policy;" + ctxt.policyName)
 	if k != "" {
 		if quantile {
 			if value, ok := mapQuantiles[k]; ok {
 				labelsListFlag.Set(fmt.Sprintf("quantile:%.2f", value))
 			}
 		} else {
-			labelsListFlag.Set(fmt.Sprintf("name:%s", k))
+			labelsListFlag.Set(fmt.Sprintf("name;%s", k))
 		}
 	}
 	dpFlag.Set(fmt.Sprintf("now,%d", v))

--- a/sinker/backend/pktvisor/pktvisor.go
+++ b/sinker/backend/pktvisor/pktvisor.go
@@ -187,7 +187,7 @@ func makePromParticle(ctxt *context, label string, k string, v interface{}, tsLi
 }
 
 func handleParticleError(ctxt *context, err error) {
-	ctxt.logger.Warn("failed to set prometheus element", zap.Error(err))
+	ctxt.logger.Error("failed to set prometheus element", zap.Error(err))
 }
 
 func camelToSnake(s string) string {

--- a/sinker/backend/pktvisor/pktvisor.go
+++ b/sinker/backend/pktvisor/pktvisor.go
@@ -166,7 +166,7 @@ func makePromParticle(ctxt *context, label string, k string, v interface{}, tsLi
 	if k != "" {
 		if quantile {
 			if value, ok := mapQuantiles[k]; ok {
-				if err := labelsListFlag.Set(fmt.Sprintf("quantile:%.2f", value)); err != nil {
+				if err := labelsListFlag.Set(fmt.Sprintf("quantile;%.2f", value)); err != nil {
 					handleParticleError(ctxt, err)
 				}
 			}

--- a/sinker/backend/pktvisor/promwrapper.go
+++ b/sinker/backend/pktvisor/promwrapper.go
@@ -26,7 +26,6 @@ func (t *labelList) String() string {
 }
 
 func (t *labelList) Set(value string) error {
-	// TODO Sometimes the value received from pktvisor has a ':' which breaks the split logic from Set method (Find a way to avoid it) i'll change : for ;
 	labelPair := strings.Split(value, ";")
 
 	if len(labelPair) != 2 {

--- a/sinker/backend/pktvisor/promwrapper.go
+++ b/sinker/backend/pktvisor/promwrapper.go
@@ -26,7 +26,9 @@ func (t *labelList) String() string {
 }
 
 func (t *labelList) Set(value string) error {
-	labelPair := strings.Split(value, ":")
+	// TODO Sometimes the value received from pktvisor has a ':' which breaks the split logic from Set method (Find a way to avoid it) i'll change : for ;
+	labelPair := strings.Split(value, ";")
+
 	if len(labelPair) != 2 {
 		return fmt.Errorf("incorrect number of arguments to '-t': %d", len(labelPair))
 	}


### PR DESCRIPTION
For ipv6 metrics, usally the label is a hex format with a colon symbol
The colon symbol was used to split and create the particle we remote write to prometheus
Changed colon for semicolon on label creation
Handle and improve errors