### PR TITLE
changing is_credentials_registered variable after register the account

### DIFF
--- a/python-test/features/steps/users.py
+++ b/python-test/features/steps/users.py
@@ -13,6 +13,7 @@ def register_orb_account(context):
     password = configs.get('password')
     if configs.get('is_credentials_registered') == 'false':
         register_account(email, password)
+        configs['is_credentials_registered'] = 'true'
     authenticate(email, password)
 
 


### PR DESCRIPTION
The account must only be registered once, so after registration the variable that indicates whether the account is registered or not  (`is_credentials_registered`) must be changed
