### PR TITLE
get correct agent through UI

### DIFF
--- a/python-test/features/steps/control_agents_ui.py
+++ b/python-test/features/steps/control_agents_ui.py
@@ -65,7 +65,7 @@ def create_agent_through_the_agents_page(context):
         EC.presence_of_all_elements_located((By.XPATH, "//span[contains(@class, 'nb-close')]")))[0].click()
     WebDriverWait(context.driver, 3).until(
         EC.presence_of_all_elements_located((By.XPATH, f"//div[contains(@class, 'agent-name') and contains(text(),"
-                                                       f"{context.agent_name})]")))[0].click()
+                                                       f"'{context.agent_name}')]")))[0].click()
     context.agent = dict()
     context.agent['id'] = WebDriverWait(context.driver, 3).until(
         EC.presence_of_all_elements_located((By.XPATH, "//label[contains(text(), 'Agent ID')]/following::p")))[0].text
@@ -82,7 +82,7 @@ def check_status_on_orb_ui(context, status, time_to_wait):
 
     while time_waiting < timeout:
         list_of_datatable_body_cell = WebDriverWait(context.driver, 3).until(
-            EC.presence_of_all_elements_located([By.XPATH, f"//div[contains(text(), {context.agent_name})]/ancestor"
+            EC.presence_of_all_elements_located([By.XPATH, f"//div[contains(text(), '{context.agent_name}')]/ancestor"
                                                            f"::datatable-body-row/descendant::i[contains(@class, "
                                                            f"'fa fa-circle')]/ancestor::div[contains(@class, "
                                                            f"'ng-star-inserted')]"]))
@@ -96,7 +96,7 @@ def check_status_on_orb_ui(context, status, time_to_wait):
     assert_that(list_of_datatable_body_cell[1].text, equal_to(status))
     WebDriverWait(context.driver, 3).until(
         EC.presence_of_all_elements_located((By.XPATH, f"//div[contains(@class, 'agent-name') and contains(text(),"
-                                                       f"{context.agent_name})]")))[0].click()
+                                                       f"'{context.agent_name}')]")))[0].click()
     agent_view_status = WebDriverWait(context.driver, 3).until(
         EC.presence_of_all_elements_located(
             (By.XPATH, "//label[contains(text(), 'Health Status')]/following::p")))[0].text

--- a/python-test/features/steps/login_ui.py
+++ b/python-test/features/steps/login_ui.py
@@ -18,7 +18,7 @@ def logs_in_orb_ui(context):
     orb_page(context)
     use_credentials(context)
     check_home_page(context)
-    context.token = authenticate(user_email, user_password)
+    context.token = authenticate(user_email, user_password)['token']
 
 
 @given("that the user is on the orb page")


### PR DESCRIPTION
- The missing quotes were resulting in the wrong agents being parsed when the orb had more than one agent.

- The change made to the authentication function had not yet been applied to the UI tests
