### PR TITLE
(hotfix): @types/node version set to 12.20.42

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -95,7 +95,7 @@
     "@types/d3-color": "1.0.5",
     "@types/jasmine": "2.5.54",
     "@types/jasminewd2": "2.0.3",
-    "@types/node": "^12.11.1",
+    "@types/node": "12.20.42",
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
     "codelyzer": "^5.1.2",


### PR DESCRIPTION
set `@types/node` version to 12.20.42.
12.20.43 breaks dependency compat.