### PR TITLE
Feat/orb 851 unlink removed sink from dataset and inactivate if in case

### DIFF
--- a/cmd/policies/main.go
+++ b/cmd/policies/main.go
@@ -276,7 +276,7 @@ func startGRPCServer(svc policies.Service, tracer opentracing.Tracer, cfg config
 func subscribeToFleetES(svc policies.Service, client *r.Client, cfg config.EsConfig, logger *zap.Logger) {
 	eventStore := rediscon.NewEventStore(svc, client, cfg.Consumer, logger)
 	logger.Info("Subscribed to Redis Event Store for agent groups")
-	if err := eventStore.Subscribe(context.Background()); err != nil {
+	if err := eventStore.SubscribeToFleet(context.Background()); err != nil {
 		logger.Error("Bootstrap service failed to subscribe to event sourcing", zap.Error(err))
 	}
 }
@@ -284,7 +284,7 @@ func subscribeToFleetES(svc policies.Service, client *r.Client, cfg config.EsCon
 func subscribeToSinksES(svc policies.Service, client *r.Client, cfg config.EsConfig, logger *zap.Logger) {
 	eventStore := rediscon.NewEventStore(svc, client, cfg.Consumer, logger)
 	logger.Info("Subscribed to Redis Event Store for sinks")
-	if err := eventStore.SubscribeSink(context.Background()); err != nil {
+	if err := eventStore.SubscribeToSink(context.Background()); err != nil {
 		logger.Error("Bootstrap service failed to subscribe to event sourcing", zap.Error(err))
 	}
 }

--- a/policies/api/http/logging.go
+++ b/policies/api/http/logging.go
@@ -256,6 +256,34 @@ func (l loggingMiddleware) ListDatasets(ctx context.Context, token string, pm po
 	return l.svc.ListDatasets(ctx, token, pm)
 }
 
+func (l loggingMiddleware) InactivateDatasetBySinkID(ctx context.Context, sinkID string, token string) (err error) {
+	defer func(begin time.Time) {
+		if err != nil {
+			l.logger.Warn("method call: inactivate_dataset_by_sink_id",
+				zap.Error(err),
+				zap.Duration("duration", time.Since(begin)))
+		} else {
+			l.logger.Info("method call: inactivate_dataset_by_sink_id",
+				zap.Duration("duration", time.Since(begin)))
+		}
+	}(time.Now())
+	return l.svc.InactivateDatasetBySinkID(ctx, sinkID, token)
+}
+
+func (l loggingMiddleware) DeleteSinkFromDataset(ctx context.Context, sinkID string, token string) (err error) {
+	defer func(begin time.Time) {
+		if err != nil {
+			l.logger.Warn("method call: delete_sink_from_dataset",
+				zap.Error(err),
+				zap.Duration("duration", time.Since(begin)))
+		} else {
+			l.logger.Info("method call: delete_sink_from_dataset",
+				zap.Duration("duration", time.Since(begin)))
+		}
+	}(time.Now())
+	return l.svc.DeleteSinkFromDataset(ctx, sinkID, token)
+}
+
 func NewLoggingMiddleware(svc policies.Service, logger *zap.Logger) policies.Service {
 	return &loggingMiddleware{logger, svc}
 }

--- a/policies/api/http/metrics.go
+++ b/policies/api/http/metrics.go
@@ -376,6 +376,50 @@ func (m metricsMiddleware) ListDatasets(ctx context.Context, token string, pm po
 	return m.svc.ListDatasets(ctx, token, pm)
 }
 
+func (m metricsMiddleware) InactivateDatasetBySinkID(ctx context.Context, sinkID string, token string) error {
+	ownerID, err := m.identify(token)
+	if err != nil {
+		return err
+	}
+
+	defer func(begin time.Time) {
+		labels := []string{
+			"method", "inactivateDatasetByGroupID",
+			"owner_id", ownerID,
+			"policy_id", "",
+			"dataset_id", "",
+		}
+
+		m.counter.With(labels...).Add(1)
+		m.latency.With(labels...).Observe(float64(time.Since(begin).Microseconds()))
+
+	}(time.Now())
+
+	return m.svc.InactivateDatasetBySinkID(ctx, sinkID, token)
+}
+
+func (m metricsMiddleware) DeleteSinkFromDataset(ctx context.Context, sinkID string, token string) error {
+	ownerID, err := m.identify(token)
+	if err != nil {
+		return err
+	}
+
+	defer func(begin time.Time) {
+		labels := []string{
+			"method", "inactivateDatasetByGroupID",
+			"owner_id", ownerID,
+			"policy_id", "",
+			"dataset_id", "",
+		}
+
+		m.counter.With(labels...).Add(1)
+		m.latency.With(labels...).Observe(float64(time.Since(begin).Microseconds()))
+
+	}(time.Now())
+
+	return m.svc.DeleteSinkFromDataset(ctx, sinkID, token)
+}
+
 func (m metricsMiddleware) identify(token string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/policies/mocks/policies.go
+++ b/policies/mocks/policies.go
@@ -22,11 +22,31 @@ type mockPoliciesRepository struct {
 }
 
 func (m *mockPoliciesRepository) InactivateDatasetBySinkID(ctx context.Context, sinkID string, ownerID string) error {
-	panic("implement me")
+	for _, ds := range m.ddb{
+		if ds.MFOwnerID == ownerID{
+			for _, sID := range ds.SinkIDs {
+				if sID == sinkID{
+					ds.Valid = false
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (m *mockPoliciesRepository) DeleteSinkFromDataset(ctx context.Context, sinkID string, ownerID string) error {
-	panic("implement me")
+	for _, ds := range m.ddb{
+		if ds.MFOwnerID == ownerID{
+			for i, sID := range ds.SinkIDs {
+				if sID == sinkID{
+					ds.SinkIDs[i] = ds.SinkIDs[len(ds.SinkIDs)-1]
+					ds.SinkIDs[len(ds.SinkIDs)-1] = ""
+					ds.SinkIDs = ds.SinkIDs[:len(ds.SinkIDs)-1]
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (m *mockPoliciesRepository) DeleteDataset(ctx context.Context, ownerID string, dsID string) error {

--- a/policies/mocks/policies.go
+++ b/policies/mocks/policies.go
@@ -21,6 +21,14 @@ type mockPoliciesRepository struct {
 	gdb            map[string][]policies.PolicyInDataset
 }
 
+func (m *mockPoliciesRepository) InactivateDatasetBySinkID(ctx context.Context, sinkID string, ownerID string) error {
+	panic("implement me")
+}
+
+func (m *mockPoliciesRepository) DeleteSinkFromDataset(ctx context.Context, sinkID string, ownerID string) error {
+	panic("implement me")
+}
+
 func (m *mockPoliciesRepository) DeleteDataset(ctx context.Context, ownerID string, dsID string) error {
 	if _, ok := m.ddb[dsID]; ok {
 		if m.ddb[dsID].MFOwnerID != ownerID {

--- a/policies/mocks/policies.go
+++ b/policies/mocks/policies.go
@@ -21,7 +21,20 @@ type mockPoliciesRepository struct {
 	gdb            map[string][]policies.PolicyInDataset
 }
 
-func (m *mockPoliciesRepository) InactivateDatasetBySinkID(ctx context.Context, sinkID string, ownerID string) error {
+func (m *mockPoliciesRepository) RetrieveAllDatasetsInternal(ctx context.Context, owner string) ([]policies.Dataset, error) {
+	var datasetList []policies.Dataset
+	id := uint64(0)
+	for _, d := range m.ddb {
+		if d.MFOwnerID == owner {
+			datasetList = append(datasetList, d)
+		}
+		id++
+	}
+
+	return datasetList, nil
+}
+
+func (m *mockPoliciesRepository) InactivateDatasetByID(ctx context.Context, sinkID string, ownerID string) error {
 	for _, ds := range m.ddb{
 		if ds.MFOwnerID == ownerID{
 			for _, sID := range ds.SinkIDs {

--- a/policies/policies.go
+++ b/policies/policies.go
@@ -102,6 +102,12 @@ type Service interface {
 
 	// ListDatasets retrieve a list of Dataset by owner
 	ListDatasets(ctx context.Context, token string, pm PageMetadata) (PageDataset, error)
+
+	// InactivateDatasetBySinkID inactivate a dataset
+	InactivateDatasetBySinkID(ctx context.Context, sinkID string, token string) error
+
+	// DeleteSinkFromDataset removes a sink from a dataset
+	DeleteSinkFromDataset(ctx context.Context, sinkID string, token string) error
 }
 
 type Repository interface {
@@ -148,4 +154,10 @@ type Repository interface {
 
 	// RetrieveAllDatasetsByOwner retrieves the subset of Datasets owned by the specified user
 	RetrieveAllDatasetsByOwner(ctx context.Context, ownerID string, pm PageMetadata) (PageDataset, error)
+
+	// InactivateDatasetBySinkID inactivate a dataset
+	InactivateDatasetBySinkID(ctx context.Context, sinkID string, ownerID string) error
+
+	// DeleteSinkFromDataset removes a sink from a dataset
+	DeleteSinkFromDataset(ctx context.Context, sinkID string, ownerID string) error
 }

--- a/policies/policies.go
+++ b/policies/policies.go
@@ -155,9 +155,12 @@ type Repository interface {
 	// RetrieveAllDatasetsByOwner retrieves the subset of Datasets owned by the specified user
 	RetrieveAllDatasetsByOwner(ctx context.Context, ownerID string, pm PageMetadata) (PageDataset, error)
 
-	// InactivateDatasetBySinkID inactivate a dataset
-	InactivateDatasetBySinkID(ctx context.Context, sinkID string, ownerID string) error
+	// InactivateDatasetByID inactivate a dataset
+	InactivateDatasetByID(ctx context.Context, sinkID string, ownerID string) error
 
 	// DeleteSinkFromDataset removes a sink from a dataset
 	DeleteSinkFromDataset(ctx context.Context, sinkID string, ownerID string) error
+
+	// RetrieveAllDatasetsInternal retrieves all datasets by owner
+	RetrieveAllDatasetsInternal(ctx context.Context, owner string) ([]Dataset, error)
 }

--- a/policies/policy_service.go
+++ b/policies/policy_service.go
@@ -328,3 +328,29 @@ func (s policiesService) ListDatasets(ctx context.Context, token string, pm Page
 	}
 	return s.repo.RetrieveAllDatasetsByOwner(ctx, ownerID, pm)
 }
+
+func (s policiesService) InactivateDatasetBySinkID(ctx context.Context, sinkID string, token string) error {
+	ownerID, err := s.identify(token)
+	if err != nil {
+		return err
+	}
+
+	if sinkID == "" {
+		return ErrMalformedEntity
+	}
+
+	return s.repo.InactivateDatasetBySinkID(ctx, sinkID, ownerID)
+}
+
+func (s policiesService) DeleteSinkFromDataset(ctx context.Context, sinkID string, token string) error {
+	ownerID, err := s.identify(token)
+	if err != nil {
+		return err
+	}
+
+	if sinkID == "" {
+		return ErrMalformedEntity
+	}
+
+	return s.repo.DeleteSinkFromDataset(ctx, sinkID, ownerID)
+}

--- a/policies/policy_service.go
+++ b/policies/policy_service.go
@@ -339,7 +339,21 @@ func (s policiesService) InactivateDatasetBySinkID(ctx context.Context, sinkID s
 		return ErrMalformedEntity
 	}
 
-	return s.repo.InactivateDatasetBySinkID(ctx, sinkID, ownerID)
+	datasets, err := s.repo.RetrieveAllDatasetsInternal(ctx, ownerID)
+	if err != nil{
+		return err
+	}
+
+	for _, ds := range datasets{
+		if len(ds.SinkIDs) == 1 && ds.SinkIDs[0] == sinkID{
+			err = s.repo.InactivateDatasetByID(ctx, ds.ID, ownerID)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (s policiesService) DeleteSinkFromDataset(ctx context.Context, sinkID string, token string) error {

--- a/policies/postgres/policies.go
+++ b/policies/postgres/policies.go
@@ -512,7 +512,7 @@ func (r policiesRepository) InactivateDatasetBySinkID(ctx context.Context, sinkI
 		"sink_ids":    sinkID,
 	}
 
-	res, err := r.db.NamedExecContext(ctx, q, params)
+	_, err := r.db.NamedExecContext(ctx, q, params)
 	if err != nil {
 		pqErr, ok := err.(*pq.Error)
 		if ok {
@@ -524,14 +524,6 @@ func (r policiesRepository) InactivateDatasetBySinkID(ctx context.Context, sinkI
 		return errors.Wrap(policies.ErrUpdateEntity, err)
 	}
 
-	count, err := res.RowsAffected()
-	if err != nil {
-		return errors.Wrap(policies.ErrUpdateEntity, err)
-	}
-
-	if count == 0 {
-		return policies.ErrInactivateDataset
-	}
 	return nil
 }
 
@@ -543,7 +535,7 @@ func (r policiesRepository) DeleteSinkFromDataset(ctx context.Context, sinkID st
 		"sink_ids":    sinkID,
 	}
 
-	res, err := r.db.NamedExecContext(ctx, q, params)
+	_, err := r.db.NamedExecContext(ctx, q, params)
 	if err != nil {
 		pqErr, ok := err.(*pq.Error)
 		if ok {
@@ -553,15 +545,6 @@ func (r policiesRepository) DeleteSinkFromDataset(ctx context.Context, sinkID st
 			}
 		}
 		return errors.Wrap(fleet.ErrUpdateEntity, err)
-	}
-
-	count, err := res.RowsAffected()
-	if err != nil {
-		return errors.Wrap(fleet.ErrRemoveEntity, err)
-	}
-
-	if count == 0 {
-		return policies.ErrNotFound
 	}
 
 	return nil

--- a/policies/redis/consumer/events.go
+++ b/policies/redis/consumer/events.go
@@ -15,3 +15,9 @@ type removeAgentGroupEvent struct {
 	token     string
 	timestamp time.Time
 }
+
+type removeSinkEvent struct {
+	sinkID    string
+	token     string
+	timestamp time.Time
+}

--- a/policies/redis/consumer/streams.go
+++ b/policies/redis/consumer/streams.go
@@ -147,7 +147,7 @@ func (es eventStore) handleAgentGroupRemove(ctx context.Context, groupID string,
 
 func (es eventStore) handleSinkRemove(ctx context.Context, sinkID string, token string) error {
 
-	err := es.policiesService.InactivateDatasetBySinkID(ctx, sinkID, token)
+	err := es.policiesService.InactivateDatasetBySinkID(context.Background(), sinkID, token)
 	if err != nil {
 		return err
 	}

--- a/policies/redis/consumer/streams.go
+++ b/policies/redis/consumer/streams.go
@@ -29,8 +29,8 @@ const (
 )
 
 type Subscriber interface {
-	Subscribe(context context.Context) error
-	SubscribeSink(context context.Context) error
+	SubscribeToFleet(context context.Context) error
+	SubscribeToSink(context context.Context) error
 }
 
 type eventStore struct {
@@ -50,7 +50,7 @@ func NewEventStore(policiesService policies.Service, client *redis.Client, escon
 	}
 }
 
-func (es eventStore) Subscribe(context context.Context) error {
+func (es eventStore) SubscribeToFleet(context context.Context) error {
 	err := es.client.XGroupCreateMkStream(context, stream, group, "$").Err()
 	if err != nil && err.Error() != exists {
 		return err
@@ -85,7 +85,7 @@ func (es eventStore) Subscribe(context context.Context) error {
 	}
 }
 
-func (es eventStore) SubscribeSink(context context.Context) error {
+func (es eventStore) SubscribeToSink(context context.Context) error {
 	err := es.client.XGroupCreateMkStream(context, streamSink, group, "$").Err()
 	if err != nil && err.Error() != exists {
 		return err

--- a/policies/redis/producer/streams.go
+++ b/policies/redis/producer/streams.go
@@ -229,6 +229,14 @@ func (e eventStore) ValidatePolicy(ctx context.Context, token string, p policies
 	return e.svc.ValidatePolicy(ctx, token, p, format, policyData)
 }
 
+func (e eventStore) InactivateDatasetBySinkID(ctx context.Context, sinkID string, token string) error {
+	return e.svc.InactivateDatasetBySinkID(ctx, sinkID, token)
+}
+
+func (e eventStore) DeleteSinkFromDataset(ctx context.Context, sinkID string, token string) error {
+	return e.svc.DeleteSinkFromDataset(ctx, sinkID, token)
+}
+
 // NewEventStoreMiddleware returns wrapper around policies service that sends
 // events to event store.
 func NewEventStoreMiddleware(svc policies.Service, client *redis.Client, logger *zap.Logger) policies.Service {

--- a/sinks/redis/producer/events.go
+++ b/sinks/redis/producer/events.go
@@ -17,7 +17,7 @@ import (
 const (
 	SinkPrefix = "sinks."
 	SinkCreate = SinkPrefix + "create"
-	SinkDelete = SinkPrefix + "delete"
+	SinkDelete = SinkPrefix + "remove"
 	SinkUpdate = SinkPrefix + "update"
 )
 
@@ -49,12 +49,14 @@ func (cce createSinkEvent) Encode() map[string]interface{} {
 }
 
 type deleteSinkEvent struct {
-	id string
+	sinkID    string
+	token string
 }
 
 func (dse deleteSinkEvent) Encode() map[string]interface{} {
 	return map[string]interface{}{
-		"id":        dse.id,
+		"sink_id":   dse.sinkID,
+		"token":     dse.token,
 		"operation": SinkDelete,
 	}
 }

--- a/sinks/redis/producer/streams.go
+++ b/sinks/redis/producer/streams.go
@@ -94,7 +94,8 @@ func (es eventStore) DeleteSink(ctx context.Context, token, id string) (err erro
 	}
 
 	event := deleteSinkEvent{
-		id: id,
+		sinkID: id,
+		token:  token,
 	}
 
 	record := &redis.XAddArgs{


### PR DESCRIPTION
- Detaches a sink of all datasets when it is removed.
- If all sinks attached to a dataset are removed, these datasets are invalidated.