### PR TITLE
fix(orb-ui): Datatable pagination and sorting issues

### DIFF
--- a/ui/src/app/@theme/styles/orb/ngx-datatable/ngx-datatable.scss
+++ b/ui/src/app/@theme/styles/orb/ngx-datatable/ngx-datatable.scss
@@ -17,7 +17,7 @@ $orb-primary-hover: #226fd2;
 $orb-primary-pressed: #0c5dc5;
 $orb-primary-focused: #0c5dc5;
 
-.orb-tag-sink {
+.orb-tag-chip {
   font-size: 12px !important;
   color: $orb-bg1;
   /*background: $orb-primary;

--- a/ui/src/app/common/interfaces/mainflux.interface.ts
+++ b/ui/src/app/common/interfaces/mainflux.interface.ts
@@ -1,146 +1,223 @@
 export interface UserGroup {
   id?: string;
+
   name?: string;
+
   description?: string;
+
   metadata?: Object;
+
   owner_id?: string;
+
   parent_id?: string;
+
   users?: User[];
 }
 
 export interface User {
   id?: string;
+
   email?: string;
+
   password?: string;
+
   picture?: string;
+
   metadata?: Object;
 }
 
 export interface Channel {
   id?: string;
+
   name?: string;
+
   metadata?: any;
+
   type?: string;
 }
 
 export interface Thing {
   id?: string;
+
   key?: string;
+
   name?: string;
+
   metadata?: any;
+
   type?: string;
 }
 
 export interface Attribute {
   name: string;
+
   channel: string;
+
   subtopic?: string;
+
   persist_state: boolean;
 }
 
 export interface Definition {
   id: string;
+
   created: Date;
+
   attributes: Attribute[];
+
   delta: number;
 }
 
 export interface Twin {
   name?: string;
+
   owner?: string;
+
   id?: string;
+
   revision?: number;
+
   created?: Date;
+
   updated?: Date;
+
   definitions?: Definition[];
+
   definition?: any; // for request
   metadata?: any;
 }
 
 export interface SenMLRec {
   bn: string;
+
   bt: number;
+
   bu: string;
+
   bver: number;
+
   n: string;
+
   t: number;
+
   u: string;
+
   v: number;
+
   vd: number;
+
   vb: number;
+
   vs: string;
 }
 
 export interface MainfluxMsg {
   name: string;
+
   time: number;
+
   unit: string;
+
   value: number;
+
   string_value: string;
+
   bool_value: boolean;
+
   data_value: string;
+
   sum: number;
+
   protocol: string;
 }
 
 export interface MsgFilters {
   offset?: number;
+
   limit?: number;
+
   publisher?: string;
+
   subtopic?: string;
+
   name?: string;
+
   v?: string;
+
   vs?: string;
+
   vd?: string;
+
   vb?: string;
+
   from?: number;
+
   to?: number;
 }
 
 export interface ReaderUrl {
   prefix?: string;
+
   suffix?: string;
 }
 
 export interface Message {
   value: number;
+
   time: number;
 }
 
 export interface Dataset {
   label?: string;
+
   messages?: Message[];
 }
 
 // Mainflux::ORB
 export interface PageFilters {
   limit?: number;
+
   offset?: number;
+
   name?: string;
+
   order?: string;
+
   dir?: string;
+
   // mainflux and other components metadata
   metadata?: string;
+
   type?: string;
+
   // orb
   tags?: Object;
 }
 
 export interface DropdownFilterItem {
   id?: string;
+
   label?: string;
+
   selected?: boolean;
+
   prop?: string;
+
+  filter?: (item: any, filter: any) => boolean;
 }
 
 export interface TableConfig {
   keys?: string[];
+
   colNames?: string[];
 }
 
 export interface TablePage {
   limit?: number;
+
   offset?: number;
+
   total?: number;
+
   rows?: Object[];
 }

--- a/ui/src/app/common/interfaces/orb/agent.interface.ts
+++ b/ui/src/app/common/interfaces/orb/agent.interface.ts
@@ -98,6 +98,6 @@ export interface Agent extends OrbEntity {
    * Internal use
    * See
    */
-  combined_tags?: string;
+  combined_tags?: any;
 
 }

--- a/ui/src/app/common/interfaces/orb/agent.interface.ts
+++ b/ui/src/app/common/interfaces/orb/agent.interface.ts
@@ -93,4 +93,11 @@ export interface Agent extends OrbEntity {
    */
   key?: string;
 
+  /**
+   * Combines tags for display in UI
+   * Internal use
+   * See
+   */
+  combined_tags?: string;
+
 }

--- a/ui/src/app/common/interfaces/orb/pagination.interface.ts
+++ b/ui/src/app/common/interfaces/orb/pagination.interface.ts
@@ -1,19 +1,37 @@
 export interface OrbPagination<T> {
   limit: number;
+
   offset: number;
+
   order: string;
+
   total?: number;
+
   name?: string;
+
   tags?: string;
+
   dir?: 'desc' | 'asc';
+
   data: T[];
+
+  next?: any;
 }
 
 export interface NgxDatabalePageInfo {
   offset?: number;
+
   pageSize?: number;
+
   limit?: number;
+
   count?: number;
+
   name?: string;
+
   tags?: string;
+
+  order?: string;
+
+  dir?: string;
 }

--- a/ui/src/app/common/services/agents/agents.service.ts
+++ b/ui/src/app/common/services/agents/agents.service.ts
@@ -208,7 +208,13 @@ export class AgentsService {
           this.paginationCache[offset || 0] = true;
           // This is the position to insert the new data
           const start = resp.offset;
-          const newData = [...this.cache.data];
+          // TODO - check rule for combination/concatenation of tags
+          // should we start to represent multiple values for a key here already or
+          // simply override value for key, assuming agent_tag is precedent.
+          const newData = [...this.cache.data.map(agent => {
+            agent.combined_tags = {...agent?.orb_tags, ...agent?.agent_tags};
+            return agent;
+          })];
           newData.splice(start, resp.limit, ...resp.agents);
           this.cache = {
             ...this.cache,

--- a/ui/src/app/common/services/agents/agents.service.ts
+++ b/ui/src/app/common/services/agents/agents.service.ts
@@ -208,22 +208,28 @@ export class AgentsService {
           this.paginationCache[offset || 0] = true;
           // This is the position to insert the new data
           const start = resp.offset;
-          // TODO - check rule for combination/concatenation of tags
-          // should we start to represent multiple values for a key here already or
-          // simply override value for key, assuming agent_tag is precedent.
-          const newData = [...this.cache.data.map(agent => {
+
+          const newData = [...this.cache.data];
+
+          newData.splice(start, resp.limit,
+            // TODO - check rule for combination/concatenation of tags
+            // should we start to represent multiple values for a key here already or
+            // simply override value for key, assuming agent_tag is precedent.
+            ...resp.agents.map(agent => {
             agent.combined_tags = {...agent?.orb_tags, ...agent?.agent_tags};
             return agent;
-          })];
-          newData.splice(start, resp.limit, ...resp.agents);
+          }));
+
           this.cache = {
             ...this.cache,
             offset: Math.floor(resp.offset / resp.limit),
             total: resp.total,
             data: newData,
           };
+
           if (name) this.cache.name = name;
           if (tags) this.cache.tags = tags;
+
           return this.cache;
         },
       )

--- a/ui/src/app/common/services/sinks/sinks.service.ts
+++ b/ui/src/app/common/services/sinks/sinks.service.ts
@@ -7,9 +7,10 @@ import { environment } from 'environments/environment';
 import { Sink } from 'app/common/interfaces/orb/sink.interface';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 import { NgxDatabalePageInfo, OrbPagination } from 'app/common/interfaces/orb/pagination.interface';
+import { delay, expand, reduce } from 'rxjs/operators';
 
 // default filters
-const defLimit: number = 20;
+const defLimit: number = 10;
 const defOrder: string = 'name';
 const defDir = 'desc';
 
@@ -96,45 +97,89 @@ export class SinksService {
       );
   }
 
+  getAllSinks() {
+    const pageInfo = SinksService.getDefaultPagination();
+    pageInfo.limit = 100;
+
+    return this.getSinks(pageInfo)
+      .pipe(
+        expand(data => {
+          return data.next ? this.getSinks(data.next) : Observable.empty();
+        }),
+        delay(250),
+        reduce<OrbPagination<Sink>>((acc, value) => {
+          acc.data.splice(value.offset, value.limit, ...value.data);
+          acc.offset = 0;
+          return acc;
+        }, this.cache),
+      );
+  }
+
   getSinks(pageInfo: NgxDatabalePageInfo, isFilter = false) {
-    const offset = pageInfo?.offset || this.cache.offset;
-    const limit = pageInfo?.limit || this.cache.limit;
-    let params = new HttpParams()
-      .set('offset', (offset * limit).toString())
-      .set('limit', limit.toString())
-      .set('order', this.cache.order)
-      .set('dir', this.cache.dir);
+    let limit = pageInfo?.limit || this.cache.limit;
+    let order = pageInfo?.order || this.cache.order;
+    let dir = pageInfo?.dir || this.cache.dir;
+    let offset = pageInfo?.offset || 0;
+    let doClean = false;
+    let params = new HttpParams();
 
     if (isFilter) {
       if (pageInfo?.name) {
-        params = params.append('name', pageInfo.name);
+        params = params.set('name', pageInfo.name);
+        // is filter different than last filter?
+        doClean = !this.paginationCache?.name || this.paginationCache?.name !== pageInfo.name;
       }
-      if (pageInfo?.tags) {
-        params.append('tags', JSON.stringify(pageInfo.tags));
-      }
-      this.paginationCache[offset] = false;
+      // was filtered, no longer
+    } else if (this.paginationCache?.isFilter === true) {
+      doClean = true;
     }
 
-    if (this.paginationCache[pageInfo?.offset]) {
+    if (pageInfo.order !== this.cache.order
+      || pageInfo.dir !== this.cache.dir) {
+      doClean = true;
+    }
+
+    if (doClean) {
+      this.clean();
+      offset = 0;
+      limit = this.cache.limit = pageInfo.limit;
+      dir = pageInfo.dir;
+      order = pageInfo.order;
+    }
+
+    if (this.paginationCache[offset]) {
       return of(this.cache);
     }
+    params = params
+      .set('offset', (offset).toString())
+      .set('limit', limit.toString())
+      .set('order', order)
+      .set('dir', dir);
 
     return this.http.get(environment.sinksUrl, { params })
       .map(
         (resp: any) => {
-          this.paginationCache[pageInfo?.offset || 0] = true;
+          this.paginationCache[pageInfo?.offset / pageInfo?.limit || 0] = true;
           // This is the position to insert the new data
-          const start = pageInfo?.offset || 0;
+          const start = pageInfo?.offset * pageInfo?.limit || 0;
           const newData = [...this.cache.data];
           newData.splice(start, resp.limit, ...resp.sinks);
           this.cache = {
             ...this.cache,
-            offset: Math.floor(resp.offset / resp.limit),
+            next: resp.offset + resp.limit < resp.total && {
+              limit: resp.limit,
+              offset: (parseInt(resp.offset, 10) + parseInt(resp.limit, 10)).toString(),
+              order: 'name',
+              dir: 'desc',
+            },
+            offset: resp.offset,
+            dir: resp.direction,
+            order: resp.order,
             total: resp.total,
             data: newData,
+            name: pageInfo?.name,
           };
-          if (pageInfo?.name) this.cache.name = pageInfo.name;
-          if (pageInfo?.tags) this.cache.tags = pageInfo.tags;
+
           return this.cache;
         },
       )

--- a/ui/src/app/pages/datasets/list/dataset.list.component.html
+++ b/ui/src/app/pages/datasets/list/dataset.list.component.html
@@ -4,7 +4,7 @@
     </xng-breadcrumb>
     <h4>All Datasets</h4>
   </header>
-  <div class="d-flex flex-column mt-4" #tableWrapper>
+  <div #tableWrapper class="d-flex flex-column mt-4">
     <div class="d-flex justify-content-between align-items-end mb-2">
       <div class="d-flex">
         <p *ngIf=" paginationControls.data && paginationControls.data.length> 0"
@@ -19,85 +19,91 @@
       <div class="d-flex">
         <div class="mr-3">
           <nb-select
-            *ngIf="tableFilters && tableFilters.length"
-            [(selected)]="filterSelectedIndex"
             (selectedChange)="onFilterSelected($event)"
+            *ngIf="tableFilters && tableFilters.length"
+            [(selected)]="selectedFilter"
             appearance="filled"
-            size="medium"
             class="d-flex justify-content-end"
-            style="width: 160px; height: 100%"
-            placeholder="Filter by">
-            <nb-option *ngFor="let conf of tableFilters" [value]="conf.id">{{ conf.label }}</nb-option>
+            placeholder="Filter by"
+            size="medium"
+            style="width: 160px; height: 100%">
+            <nb-option *ngFor="let conf of tableFilters" [value]="conf">{{ conf.label }}</nb-option>
           </nb-select>
         </div>
-        <nb-form-field *ngIf="filterSelectedIndex =='1'">
-          <nb-icon nbPrefix icon="search-outline" pack="eva"></nb-icon>
-          <input nbInput
-                 (keyup)="getDatasets()"
+        <nb-form-field *ngIf="selectedFilter">
+          <nb-icon icon="search-outline" nbPrefix pack="eva"></nb-icon>
+          <input (input)="applyFilter()"
+                 [(ngModel)]="filterValue"
                  [placeholder]="searchPlaceholder"
-                 type="text"
                  fieldSize="medium"
-                 [(ngModel)]="paginationControls.tags"/>
-        </nb-form-field>
-        <nb-form-field *ngIf="filterSelectedIndex =='0'">
-          <nb-icon nbPrefix icon="search-outline" pack="eva"></nb-icon>
-          <input nbInput
-                 (keyup)="getDatasets()"
-                 [placeholder]="searchPlaceholder"
-                 type="text"
-                 fieldSize="medium"
-                 [(ngModel)]="paginationControls.name"/>
+                 nbInput
+                 type="text"/>
         </nb-form-field>
       </div>
     </div>
     <div class="add-dataset-container">
-      <button nbButton
+      <button (click)="onOpenAdd()"
               ghost="true"
-              status="primary"
-              (click)="onOpenAdd()">
-        <i class="fa fa-plus">&nbsp;</i>New Set</button>
+              nbButton
+              status="primary">
+        <i class="fa fa-plus">&nbsp;</i>New Set
+      </button>
     </div>
     <ngx-datatable
       #table
-      class="orb"
-      style="height: calc(100vh - 300px)"
-      [loadingIndicator]="loading"
-      [externalPaging]="true"
-      [externalSorting]="true"
-      [count]="paginationControls.total"
+      [columnMode]="columnMode.flex"
+      [columns]="columns"
+      [footerHeight]="50"
+      [headerHeight]="50"
       [limit]="paginationControls.limit"
-      [offset]="paginationControls.offset"
+      [loadingIndicator]="loading"
+      [rowHeight]="50"
       [rows]="paginationControls.data"
       [scrollbarV]="true"
-      (page)='getDatasets($event)'
-      [columns]="columns"
-      [columnMode]="columnMode.flex"
-      [headerHeight]="50"
-      [footerHeight]="50"
-      [rowHeight]="50">
+      [sorts]="tableSorts"
+      class="orb"
+      style="height: calc(62vh)">
     </ngx-datatable>
   </div>
 </div>
 
-<ng-template #actionsTemplateCell let-row="row" let-value="value" let-i="index">
+<ng-template #nameTemplateCell let-i="index" let-row="row" let-value="value">
+  <div nbTooltip="{{ row.id }}">
+    {{ row.name }}
+  </div>
+</ng-template>
 
+<ng-template #validTemplateCell let-i="index" let-row="row" let-value="value">
+  <div>
+    <i aria-hidden="true" class="fa fa-circle orb-service-{{ row.valid }}"></i>
+    {{ row.valid ? 'True' : 'False' }}
+  </div>
+</ng-template>
+
+<ng-template #sinksTemplateCell let-i="index" let-row="row" let-value="value">
+  <div nbTooltip="{{ value | json }}">
+    {{ value?.length }}
+  </div>
+</ng-template>
+
+<ng-template #actionsTemplateCell let-i="index" let-row="row" let-value="value">
   <div class="d-flex flex-row">
-    <button nbButton
-            ghost
+    <button (click)="openDetailsModal(row)"
             class="orb-action-hover detail-button"
-            (click)="openDetailsModal(row)">
+            ghost
+            nbButton>
       <nb-icon icon="search-outline"></nb-icon>
     </button>
-    <button nbButton
-            ghost
+    <button (click)="onOpenEdit(row)"
             class="orb-action-hover edit-button"
-            (click)="onOpenEdit(row)">
+            ghost
+            nbButton>
       <nb-icon icon="edit-outline"></nb-icon>
     </button>
-    <button nbButton
-            ghost
+    <button (click)="openDeleteModal(row)"
             class="orb-action-hover del-button"
-            (click)="openDeleteModal(row)">
+            ghost
+            nbButton>
       <nb-icon icon="trash-2-outline"></nb-icon>
     </button>
   </div>

--- a/ui/src/app/pages/datasets/list/dataset.list.component.scss
+++ b/ui/src/app/pages/datasets/list/dataset.list.component.scss
@@ -1,18 +1,18 @@
 h4 {
   font-family: 'Montserrat', sans-serif;
+  font-size: 24px;
   font-style: normal;
   font-weight: normal;
-  font-size: 24px;
   line-height: 32px;
 }
 
 .dataset-summary {
   .dataset-info-regular {
-    color: #ffffff;
+    color: #fff;
 
     &::before {
-      content: 'You have\00a0';
       color: #969fb9;
+      content: 'You have\00a0';
     }
   }
 
@@ -27,19 +27,19 @@ h4 {
 
 .filter-dropdown {
   display: flex;
+  padding-right: 50px;
   position: absolute;
   right: 0;
-  padding-right: 50px;
   transform: translateY(-50px);
 }
 
 .button-new-dataset {
-  width: 155px;
-  height: 236px;
-  border: 1px solid #969fb9;
   background: #232940;
+  border: 1px solid #969fb9;
   box-sizing: border-box;
+  height: 236px;
   justify-content: flex-end;
+  width: 155px;
 
   &::ng-deep div {
     display: flex !important;
@@ -49,22 +49,22 @@ h4 {
   &:hover {
     background: #232940;
     border: 1px solid #3089fc;
-    box-sizing: border-box;
     border-radius: 4px;
+    box-sizing: border-box;
   }
 
   &:active {
     background: #232940;
     border: 1px solid #3089fc;
-    box-sizing: border-box;
     border-radius: 4px;
+    box-sizing: border-box;
   }
 
   &:default {
     background: #232940;
     border: 1px solid #969fb9;
-    box-sizing: border-box;
     border-radius: 4px;
+    box-sizing: border-box;
   }
 }
 
@@ -76,55 +76,67 @@ tr div p {
 
 ::ng-deep {
   header p {
-    font-family: 'Montserrat', sans-serif;
-    font-style: normal;
-    font-weight: normal;
-    font-size: 14px !important;
-    line-height: 20px;
-
-    width: 250px;
-    height: 20px;
-    margin-left: 16px;
-    margin-top: 24px;
-
-    display: flex;
     align-items: center;
+    display: flex;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 14px !important;
+    font-style: normal;
+
+    font-weight: normal;
+    height: 20px;
+    line-height: 20px;
+    margin-left: 16px;
+
+    margin-top: 24px;
+    width: 250px;
   }
 
   .orb-breadcrumb {
     display: flex;
     font-family: 'Montserrat', sans-serif;
+    font-size: 12px;
     font-style: normal;
     font-weight: 500;
-    font-size: 12px;
     line-height: 12px;
 
     ::ng-deep {
       .xng-breadcrumb-trail {
-        color: #ffffff;
+        color: #fff;
         margin-bottom: 0;
       }
+
       .xng-breadcrumb-link {
-        text-decoration: none !important;
         color: #969fb9 !important;
+        text-decoration: none !important;
       }
-     .xng-breadcrumb-separator {
-        text-decoration: none !important;
+
+      .xng-breadcrumb-separator {
         color: #969fb9 !important;
+        text-decoration: none !important;
       }
     }
   }
 }
 
 .add-dataset-container {
-  position: relative;
   height: 0;
+  position: relative;
 
   button {
     float: right;
-    top: 5px;
     position: relative;
-    z-index: 2;
     right: 5px;
+    top: 5px;
+    z-index: 2;
+  }
+}
+
+.orb-service- {
+  &true {
+    color: #6fcf97;
+  }
+
+  &false {
+    color: #df316f;
   }
 }

--- a/ui/src/app/pages/datasets/list/dataset.list.component.ts
+++ b/ui/src/app/pages/datasets/list/dataset.list.component.ts
@@ -11,7 +11,6 @@ import {
 import { DropdownFilterItem } from 'app/common/interfaces/mainflux.interface';
 import { ColumnMode, DatatableComponent, TableColumn } from '@swimlane/ngx-datatable';
 import { NgxDatabalePageInfo, OrbPagination } from 'app/common/interfaces/orb/pagination.interface';
-import { Debounce } from 'app/shared/decorators/utils';
 import { Dataset } from 'app/common/interfaces/orb/dataset.policy.interface';
 import { DatasetPoliciesService } from 'app/common/services/dataset/dataset.policies.service';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -36,9 +35,13 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
 
   searchPlaceholder = 'Search by name';
 
-  filterSelectedIndex = '0';
-
   // templates
+  @ViewChild('nameTemplateCell') nameTemplateCell: TemplateRef<any>;
+
+  @ViewChild('validTemplateCell') validTemplateCell: TemplateRef<any>;
+
+  @ViewChild('sinksTemplateCell') sinksTemplateCell: TemplateRef<any>;
+
   @ViewChild('actionsTemplateCell') actionsTemplateCell: TemplateRef<any>;
 
   tableFilters: DropdownFilterItem[] = [
@@ -47,6 +50,25 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
       label: 'Name',
       prop: 'name',
       selected: false,
+      filter: (dataset, name) => dataset?.name.includes(name),
+    },
+    {
+      id: '1',
+      label: 'Valid',
+      prop: 'valid',
+      selected: false,
+      filter: (dataset, valid) => `${ dataset?.valid }`.includes(name),
+    },
+  ];
+
+  selectedFilter = this.tableFilters[0];
+
+  filterValue = null;
+
+  tableSorts = [
+    {
+      prop: 'name',
+      dir: 'asc',
     },
   ];
 
@@ -79,7 +101,7 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
 
   ngOnInit() {
     this.datasetPoliciesService.clean();
-    this.getDatasets();
+    this.getAllDatasets();
   }
 
   ngAfterViewInit() {
@@ -90,6 +112,23 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
         resizeable: false,
         flexGrow: 5,
         minWidth: 90,
+        cellTemplate: this.nameTemplateCell,
+      },
+      {
+        prop: 'valid',
+        name: 'Valid',
+        resizeable: false,
+        flexGrow: 1,
+        minWidth: 25,
+        cellTemplate: this.validTemplateCell,
+      },
+      {
+        prop: 'sink_ids',
+        name: 'Sinks',
+        resizeable: false,
+        flexGrow: 1,
+        minWidth: 25,
+        cellTemplate: this.sinksTemplateCell,
       },
       {
         name: '',
@@ -105,22 +144,25 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
     this.cdr.detectChanges();
   }
 
+  getAllDatasets(): void {
+    this.datasetPoliciesService.getAllDatasets().subscribe(resp => {
+      this.paginationControls.data = resp.data;
+      this.paginationControls.total = resp.data.length;
+      this.paginationControls.offset = resp.offset / resp.limit;
+      this.loading = false;
+      this.cdr.markForCheck();
+    });
+  }
 
-  @Debounce(500)
   getDatasets(pageInfo: NgxDatabalePageInfo = null): void {
-    const isFilter = this.paginationControls.name?.length > 0 || this.paginationControls.tags?.length > 0;
-
-    if (isFilter) {
-      pageInfo = {
-        offset: this.paginationControls.offset,
-        limit: this.paginationControls.limit,
-      };
-      if (this.paginationControls.name?.length > 0) pageInfo.name = this.paginationControls.name;
-      if (this.paginationControls.tags?.length > 0) pageInfo.tags = this.paginationControls.tags;
-    }
+    const finalPageInfo = { ...pageInfo };
+    finalPageInfo.dir = 'desc';
+    finalPageInfo.order = 'name';
+    finalPageInfo.limit = this.paginationControls.limit;
+    finalPageInfo.offset = pageInfo?.offset * pageInfo?.limit || 0;
 
     this.loading = true;
-    this.datasetPoliciesService.getDatasetPolicies(pageInfo, isFilter).subscribe(
+    this.datasetPoliciesService.getDatasetPolicies(pageInfo).subscribe(
       (resp: OrbPagination<Dataset>) => {
         this.paginationControls = resp;
         this.paginationControls.offset = pageInfo?.offset || 0;
@@ -146,8 +188,22 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
     );
   }
 
-  onFilterSelected(selectedIndex) {
-    this.searchPlaceholder = `Search by ${ this.tableFilters[selectedIndex].label }`;
+  onFilterSelected(filter) {
+    this.searchPlaceholder = `Search by ${ filter.label }`;
+    this.filterValue = null;
+  }
+
+  applyFilter() {
+    if (!this.paginationControls || !this.paginationControls?.data) return;
+
+    if (!this.filterValue || this.filterValue === '') {
+      this.table.rows = this.paginationControls.data;
+    } else {
+      this.table.rows = this.paginationControls.data.filter(sink => this.filterValue.split(/[,;]+/gm).reduce((prev, curr) => {
+        return this.selectedFilter.filter(sink, curr) && prev;
+      }, true));
+    }
+    this.paginationControls.offset = 0;
   }
 
   openDeleteModal(row: any) {
@@ -179,13 +235,6 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
       } else {
         this.getDatasets();
       }
-    });
-  }
-
-  searchDatasetItemByName(input) {
-    this.getDatasets({
-      ...this.paginationControls,
-      [this.tableFilters[this.filterSelectedIndex].prop]: input,
     });
   }
 }

--- a/ui/src/app/pages/datasets/policies.agent/list/agent.policy.list.component.html
+++ b/ui/src/app/pages/datasets/policies.agent/list/agent.policy.list.component.html
@@ -4,89 +4,83 @@
     </xng-breadcrumb>
     <h4>All Policies</h4>
   </header>
-  <div class="d-flex flex-column mt-4" #tableWrapper>
-    <div class="d-flex justify-content-between align-items-end mb-2">
+  <div #tableWrapper class="d-flex flex-column mt-4">
+    <div class="d-flex justify-content-end align-items-end mb-2">
       <div class="d-flex">
         <div class="mr-3">
           <nb-select
-            *ngIf="tableFilters && tableFilters.length"
-            [(selected)]="filterSelectedIndex"
             (selectedChange)="onFilterSelected($event)"
+            *ngIf="tableFilters && tableFilters.length"
+            [(selected)]="selectedFilter"
             appearance="filled"
-            size="medium"
             class="d-flex justify-content-end"
-            style="width: 160px; height: 100%"
-            placeholder="Filter by">
-            <nb-option *ngFor="let conf of tableFilters" [value]="conf.id">{{ conf.label }}</nb-option>
+            placeholder="Filter by"
+            size="medium"
+            style="width: 160px; height: 100%">
+            <nb-option *ngFor="let conf of tableFilters" [value]="conf">{{ conf.label }}</nb-option>
           </nb-select>
         </div>
-        <nb-form-field *ngIf="filterSelectedIndex =='1'">
-          <nb-icon nbPrefix icon="search-outline" pack="eva"></nb-icon>
-          <input nbInput
-                 (keyup)="getAgentsPolicies()"
+        <nb-form-field *ngIf="selectedFilter">
+          <nb-icon icon="search-outline" nbPrefix pack="eva"></nb-icon>
+          <input (input)="applyFilter()"
+                 [(ngModel)]="filterValue"
                  [placeholder]="searchPlaceholder"
-                 type="text"
                  fieldSize="medium"
-                 [(ngModel)]="paginationControls.tags"/>
-        </nb-form-field>
-        <nb-form-field *ngIf="filterSelectedIndex =='0'">
-          <nb-icon nbPrefix icon="search-outline" pack="eva"></nb-icon>
-          <input nbInput
-                 (keyup)="getAgentsPolicies()"
-                 [placeholder]="searchPlaceholder"
-                 type="text"
-                 fieldSize="medium"
-                 [(ngModel)]="paginationControls.name"/>
+                 nbInput
+                 type="text"/>
         </nb-form-field>
       </div>
     </div>
     <div class="add-agent-policy-container">
-      <button nbButton
+      <button (click)="onOpenAdd()"
               ghost="true"
-              status="primary"
-              (click)="onOpenAdd()">
-        <i class="fa fa-plus">&nbsp;</i>New Policy</button>
+              nbButton
+              status="primary">
+        <i class="fa fa-plus">&nbsp;</i>New Policy
+      </button>
     </div>
     <ngx-datatable
       #table
-      class="orb"
-      style="height: calc(100vh - 300px)"
-      [loadingIndicator]="loading"
-      [externalPaging]="true"
-      [externalSorting]="true"
-      [count]="paginationControls.total"
+      [columnMode]="columnMode.flex"
+      [columns]="columns"
+      [footerHeight]="50"
+      [headerHeight]="50"
       [limit]="paginationControls.limit"
-      [offset]="paginationControls.offset"
+      [loadingIndicator]="loading"
+      [rowHeight]="50"
       [rows]="paginationControls.data"
       [scrollbarV]="true"
-      (page)='getAgentsPolicies($event)'
-      [columns]="columns"
-      [columnMode]="columnMode.flex"
-      [headerHeight]="50"
-      [footerHeight]="50"
-      [rowHeight]="50">
+      [sorts]="tableSorts"
+      class="orb"
+      style="height: calc(62vh)">
     </ngx-datatable>
   </div>
 </div>
 
-<ng-template #actionsTemplateCell let-row="row" let-value="value" let-i="index">
+<ng-template #nameTemplateCell let-i="index" let-row="row" let-value="value">
+  <div nbTooltip="{{ row.id }}">
+    {{ row.name }}
+  </div>
+</ng-template>
+
+<ng-template #actionsTemplateCell let-i="index" let-row="row" let-value="value">
   <div class="d-flex flex-row">
-    <button nbButton
-            ghost
+    <button (click)="openDetailsModal(row)"
             class="orb-action-hover detail-button"
-            (click)="openDetailsModal(row)">
+            ghost
+            nbButton>
       <nb-icon icon="search-outline"></nb-icon>
     </button>
-    <button nbButton
-            ghost
+    <button (click)="onOpenEdit(row)"
             class="orb-action-hover edit-button"
-            (click)="onOpenEdit(row)">
+            ghost
+            nbButton>
       <nb-icon icon="edit-outline"></nb-icon>
     </button>
-    <button nbButton
-            ghost
+    <button (click)="openDeleteModal(row)"
             class="orb-action-hover del-button"
-            (click)="openDeleteModal(row)">
+            ghost
+            nbButton>
       <nb-icon icon="trash-2-outline"></nb-icon>
     </button>
   </div>

--- a/ui/src/app/pages/datasets/policies.agent/list/agent.policy.list.component.ts
+++ b/ui/src/app/pages/datasets/policies.agent/list/agent.policy.list.component.ts
@@ -16,7 +16,6 @@ import { NbDialogService } from '@nebular/theme';
 import { AgentPoliciesService } from 'app/common/services/agents/agent.policies.service';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Debounce } from 'app/shared/decorators/utils';
 import { AgentPolicyDeleteComponent } from 'app/pages/datasets/policies.agent/delete/agent.policy.delete.component';
 import { AgentPolicyDetailsComponent } from 'app/pages/datasets/policies.agent/details/agent.policy.details.component';
 import { DatePipe } from '@angular/common';
@@ -39,7 +38,7 @@ export class AgentPolicyListComponent implements OnInit, AfterViewInit, AfterVie
 
   searchPlaceholder = 'Search by name';
 
-  filterSelectedIndex = '0';
+  @ViewChild('nameTemplateCell') nameTemplateCell: TemplateRef<any>;
 
   @ViewChild('actionsTemplateCell') actionsTemplateCell: TemplateRef<any>;
 
@@ -49,12 +48,32 @@ export class AgentPolicyListComponent implements OnInit, AfterViewInit, AfterVie
       label: 'Name',
       prop: 'name',
       selected: false,
+      filter: (policy, name) => policy?.name.includes(name),
     },
     {
       id: '1',
+      label: 'Description',
+      prop: 'description',
+      selected: false,
+      filter: (policy, description) => policy?.description.includes(description),
+    },
+    {
+      id: '2',
       label: 'Version',
       prop: 'version',
       selected: false,
+      filter: (policy, version) => policy?.version.includes(version),
+    },
+  ];
+
+  selectedFilter = this.tableFilters[0];
+
+  filterValue = null;
+
+  tableSorts = [
+    {
+      prop: 'name',
+      dir: 'asc',
     },
   ];
 
@@ -97,35 +116,37 @@ export class AgentPolicyListComponent implements OnInit, AfterViewInit, AfterVie
         prop: 'name',
         name: 'Policy Name',
         resizeable: false,
-        flexGrow: 3,
-        minWidth: 90,
+        canAutoResize: true,
+        flexGrow: 2,
+        minWidth: 120,
+        cellTemplate: this.nameTemplateCell,
       },
       {
         prop: 'description',
         name: 'Description',
         resizeable: false,
         flexGrow: 4,
-        minWidth: 180,
+        minWidth: 120,
       },
       {
-        prop: 'version',
+        prop: 'schema_version',
         name: 'Version',
         resizeable: false,
-        flexGrow: 2,
-        minWidth: 60,
+        flexGrow: 1,
+        minWidth: 50,
       },
       {
         prop: 'ts_last_modified',
-        pipe: {transform: (value) => this.datePipe.transform(value, 'MMM d, y, HH:mm:ss z')},
+        pipe: { transform: (value) => this.datePipe.transform(value, 'M/d/yy, HH:mm z') },
         name: 'Last Modified',
-        minWidth: 90,
+        minWidth: 140,
         flexGrow: 2,
         resizeable: false,
       },
       {
         name: '',
         prop: 'actions',
-        minWidth: 130,
+        minWidth: 100,
         resizeable: false,
         sortable: false,
         flexGrow: 2,
@@ -136,21 +157,25 @@ export class AgentPolicyListComponent implements OnInit, AfterViewInit, AfterVie
     this.cdr.detectChanges();
   }
 
-  @Debounce(500)
-  getAgentsPolicies(pageInfo: NgxDatabalePageInfo = null): void {
-    const isFilter = this.paginationControls.name?.length > 0 || this.paginationControls.tags?.length > 0;
+  getAllPolicies(): void {
+    this.agentPoliciesService.getAllAgentPolicies().subscribe(resp => {
+      this.paginationControls.data = resp.data;
+      this.paginationControls.total = resp.data.length;
+      this.paginationControls.offset = resp.offset / resp.limit;
+      this.loading = false;
+      this.cdr.markForCheck();
+    });
+  }
 
-    if (isFilter) {
-      pageInfo = {
-        offset: this.paginationControls.offset,
-        limit: this.paginationControls.limit,
-      };
-      if (this.paginationControls.name?.length > 0) pageInfo.name = this.paginationControls.name;
-      if (this.paginationControls.tags?.length > 0) pageInfo.tags = this.paginationControls.tags;
-    }
+  getAgentsPolicies(pageInfo: NgxDatabalePageInfo = null): void {
+    const finalPageInfo = { ...pageInfo };
+    finalPageInfo.dir = 'desc';
+    finalPageInfo.order = 'name';
+    finalPageInfo.limit = this.paginationControls.limit;
+    finalPageInfo.offset = pageInfo?.offset * pageInfo?.limit || 0;
 
     this.loading = true;
-    this.agentPoliciesService.getAgentsPolicies(pageInfo, isFilter).subscribe(
+    this.agentPoliciesService.getAgentsPolicies(finalPageInfo).subscribe(
       (resp: OrbPagination<AgentPolicy>) => {
         this.paginationControls = resp;
         this.paginationControls.offset = pageInfo?.offset || 0;
@@ -173,8 +198,22 @@ export class AgentPolicyListComponent implements OnInit, AfterViewInit, AfterVie
     });
   }
 
-  onFilterSelected(selectedIndex) {
-    this.searchPlaceholder = `Search by ${ this.tableFilters[selectedIndex].label }`;
+  onFilterSelected(filter) {
+    this.searchPlaceholder = `Search by ${ filter.label }`;
+    this.filterValue = null;
+  }
+
+  applyFilter() {
+    if (!this.paginationControls || !this.paginationControls?.data) return;
+
+    if (!this.filterValue || this.filterValue === '') {
+      this.table.rows = this.paginationControls.data;
+    } else {
+      this.table.rows = this.paginationControls.data.filter(sink => this.filterValue.split(/[,;]+/gm).reduce((prev, curr) => {
+        return this.selectedFilter.filter(sink, curr) && prev;
+      }, true));
+    }
+    this.paginationControls.offset = 0;
   }
 
   openDeleteModal(row: any) {
@@ -206,13 +245,6 @@ export class AgentPolicyListComponent implements OnInit, AfterViewInit, AfterVie
       } else {
         this.getAgentsPolicies();
       }
-    });
-  }
-
-  searchAgentByName(input) {
-    this.getAgentsPolicies({
-      ...this.paginationControls,
-      [this.tableFilters[this.filterSelectedIndex].prop]: input,
     });
   }
 }

--- a/ui/src/app/pages/fleet/agents/add/agent.add.component.html
+++ b/ui/src/app/pages/fleet/agents/add/agent.add.component.html
@@ -77,7 +77,7 @@
                   *ngFor="let tag of selectedTags | keyvalue; index as i;"
                   [attr.data-orb-qa-id]="'orb_tag_' + i"
                   [style.background-color]="tag | tagcolor"
-                  class="orb-tag-sink ">
+                  class="orb-tag-chip ">
                   {{tag | tagchip}}
                   <nb-icon (click)="onRemoveTag(tag.key)"
                            class="ml-1"
@@ -87,7 +87,7 @@
                 <mat-chip
                   *ngIf="(selectedTags | json) === '{}'"
                   [style.background-color]="'notag' | tagcolor"
-                  class="orb-tag-sink ">
+                  class="orb-tag-chip ">
                   No tag added
                 </mat-chip>
               </mat-chip-list>
@@ -195,13 +195,13 @@
                   *ngFor="let tag of selectedTags | keyvalue; index as i;"
                   [attr.data-orb-qa-id]="'review-tag_' + i"
                   [style.background-color]="tag | tagcolor"
-                  class="orb-tag-sink ">
+                  class="orb-tag-chip ">
                   {{tag | tagchip}}
                 </mat-chip>
                 <mat-chip
                   *ngIf="(selectedTags | json) === '{}'"
                   [style.background-color]="'notag' | tagcolor"
-                  class="orb-tag-sink ">
+                  class="orb-tag-chip ">
                   No tag added
                 </mat-chip>
               </mat-chip-list>

--- a/ui/src/app/pages/fleet/agents/details/agent.details.component.html
+++ b/ui/src/app/pages/fleet/agents/details/agent.details.component.html
@@ -34,13 +34,13 @@
         <div>
           <mat-chip-list style="min-width: 0.2pc; min-height: 0.2pc;">
             <mat-chip
-                class="orb-tag-sink "
+                class="orb-tag-chip "
                 *ngFor="let tag of agent.agent_tags | keyvalue | tagchiplist"
                 [style.background-color]="tag | tagcolor">
                 {{tag}}
             </mat-chip>
             <mat-chip
-                class="orb-tag-sink "
+                class="orb-tag-chip "
                 *ngFor="let tag of agent.orb_tags | keyvalue | tagchiplist"
                 [style.background-color]="tag | tagcolor">
                 {{tag}}

--- a/ui/src/app/pages/fleet/agents/list/agent.list.component.html
+++ b/ui/src/app/pages/fleet/agents/list/agent.list.component.html
@@ -87,18 +87,18 @@
 </ng-template>
 
 <ng-template #agentTagsTemplateCell let-i="index" let-row="row" let-value="value">
-  <div class="d-flex">
-    <mat-chip-list nbTooltip="{{ row?.combined_tags | json }}">
+  <div class="d-block">
+    <mat-chip-list nbTooltip="{{ row.combined_tags | json }}">
       <mat-chip
-        *ngFor="let tag of row?.combined_tags | keyvalue | tagchiplist"
+        *ngFor="let tag of value | keyvalue | slice:0:3"
         [style.background-color]="tag | tagcolor"
-        class="orb-tag-sink ">
-        {{tag}}
+        class="orb-tag-chip ">
+        {{tag | tagchip}}
       </mat-chip>
       <mat-chip
         *ngIf="(row?.orb_tags | json) === '{}' && (row?.agent_tags | json) === '{}'"
         [style.background-color]="'notag' | tagcolor"
-        class="orb-tag-sink ">
+        class="orb-tag-chip ">
         No tags were created
       </mat-chip>
     </mat-chip-list>
@@ -110,7 +110,7 @@
     Never
   </div>
   <div *ngIf="row.state !== 'new'" class="d-flex">
-    {{ value | date:'short' }}
+    {{ value | date:'M/d/yy, HH:mm z' }}
   </div>
 </ng-template>
 

--- a/ui/src/app/pages/fleet/agents/list/agent.list.component.html
+++ b/ui/src/app/pages/fleet/agents/list/agent.list.component.html
@@ -13,7 +13,7 @@
         </p>
         <p *ngIf=" paginationControls.data && paginationControls.data.filter(filterByError).length > 0 "
            class="ns1red">
-          &nbsp;<a><strong> {{paginationControls.data.filter(filterByError).length}}</strong> of them  have errors</a>.
+          &nbsp;<a><strong> {{paginationControls.data.filter(filterByError).length}}</strong> of them have errors</a>.
         </p>
         <p *ngIf="paginationControls.data && paginationControls.data.length === 0"
            class="sink-info-accent mb-0">
@@ -23,104 +23,80 @@
       <div class="d-flex">
         <div class="mr-3">
           <nb-select
-            *ngIf="tableFilters && tableFilters.length"
-            [(selected)]="filterSelectedIndex"
             (selectedChange)="onFilterSelected($event)"
+            *ngIf="tableFilters && tableFilters.length"
+            [(selected)]="selectedFilter"
             appearance="filled"
-            size="medium"
             class="d-flex justify-content-end"
-            style="width: 160px; height: 100%"
-            placeholder="Filter by">
-            <nb-option *ngFor="let conf of tableFilters" [value]="conf.id">{{ conf.label }}</nb-option>
+            placeholder="Filter by"
+            size="medium"
+            style="width: 160px; height: 100%">
+            <nb-option *ngFor="let conf of tableFilters" [value]="conf">{{ conf.label }}</nb-option>
           </nb-select>
         </div>
-        <nb-form-field *ngIf="filterSelectedIndex =='1'">
-          <nb-icon nbPrefix icon="search-outline" pack="eva"></nb-icon>
-          <input nbInput
-                 (keyup)="getAgents()"
+        <nb-form-field *ngIf="selectedFilter">
+          <nb-icon icon="search-outline" nbPrefix pack="eva"></nb-icon>
+          <input (keyup)="applyFilter()"
+                 [(ngModel)]="filterValue"
                  [placeholder]="searchPlaceholder"
-                 type="text"
                  fieldSize="medium"
-                 [(ngModel)]="paginationControls.tags"/>
-        </nb-form-field>
-        <nb-form-field *ngIf="filterSelectedIndex =='0'">
-          <nb-icon nbPrefix icon="search-outline" pack="eva"></nb-icon>
-          <input nbInput
-                 (keyup)="getAgents()"
-                 [placeholder]="searchPlaceholder"
-                 type="text"
-                 fieldSize="medium"
-                 [(ngModel)]="paginationControls.name"/>
+                 nbInput
+                 type="text"/>
         </nb-form-field>
       </div>
     </div>
     <div class="add-agent-container">
-      <button nbButton
+      <button (click)="onOpenAdd()"
               ghost="true"
-              status="primary"
-              (click)="onOpenAdd()">
+              nbButton
+              status="primary">
         <i class="fa fa-plus">&nbsp;</i>{{strings.list.create}}</button>
     </div>
     <ngx-datatable
-        #table
-        class="orb"
-        style="height: calc(100vh - 300px)"
-        [loadingIndicator]="loading"
-        [externalPaging]="true"
-        [externalSorting]="true"
-        [count]="paginationControls.total"
-        [limit]="paginationControls.limit"
-        [offset]="paginationControls.offset"
-        [rows]="paginationControls.data"
-        [scrollbarV]="true"
-        (page)='getAgents($event)'
-        [columns]="columns"
-        [columnMode]="columnMode.flex"
-        [headerHeight]="50"
-        [footerHeight]="50"
-        [rowHeight]="50">
+      #table
+      [columnMode]="columnMode.flex"
+      [columns]="columns"
+      [footerHeight]="50"
+      [headerHeight]="50"
+      [limit]="paginationControls.limit"
+      [loadingIndicator]="loading"
+      [rowHeight]="50"
+      [rows]="paginationControls.data"
+      [scrollbarV]="true"
+      [sorts]="tableSorts"
+      class="orb"
+      style="height: calc(62vh)">
     </ngx-datatable>
   </div>
 </div>
 
-<ng-template #agentNameTemplateCell let-row="row" let-value="value" let-i="index">
-  <div class="agent-name" (click)="onOpenView(row)">
+<ng-template #agentNameTemplateCell let-i="index" let-row="row" let-value="value">
+  <div (click)="onOpenView(row)"
+       nbTooltip="View Details for {{ row.id }}"
+       class="agent-name">
     {{ value }}
   </div>
 </ng-template>
 
-<ng-template #agentStateTemplateCell let-row="row" let-value="value" let-i="index">
+<ng-template #agentStateTemplateCell let-i="index" let-row="row" let-value="value">
   <div>
-    <div *ngIf="row.state === 'active'">
-      <i class="fa fa-circle orb-service-active"
-         aria-hidden="true"></i>
-      {{ row.state | titlecase }}
-    </div>
-    <div *ngIf="row.state !== 'active'">
-      <i class="fa fa-circle orb-service-{{row.state}}"
-         aria-hidden="true"></i>
-      {{ row.state | titlecase }}
-    </div>
+    <i aria-hidden="true"
+       class="fa fa-circle orb-service-{{row.state}}"></i>
+    {{ row.state | titlecase }}
   </div>
 </ng-template>
 
-<ng-template #agentTagsTemplateCell let-row="row" let-value="value" let-i="index">
+<ng-template #agentTagsTemplateCell let-i="index" let-row="row" let-value="value">
   <div class="d-flex">
-    <mat-chip-list>
+    <mat-chip-list nbTooltip="{{ row?.combined_tags | json }}">
       <mat-chip
-          class="orb-tag-sink "
-          *ngFor="let tag of row.agent_tags | keyvalue | tagchiplist"
-          [style.background-color]="tag | tagcolor">
+        *ngFor="let tag of row?.combined_tags | keyvalue | tagchiplist"
+        [style.background-color]="tag | tagcolor"
+        class="orb-tag-sink ">
         {{tag}}
       </mat-chip>
       <mat-chip
-          class="orb-tag-sink"
-          *ngFor="let tag of row.orb_tags | keyvalue | tagchiplist"
-          [style.background-color]="tag | tagcolor">
-        {{tag}}
-      </mat-chip>
-      <mat-chip
-        *ngIf="(row.orb_tags | json) === '{}' && (row.agent_tags | json) === '{}'"
+        *ngIf="(row?.orb_tags | json) === '{}' && (row?.agent_tags | json) === '{}'"
         [style.background-color]="'notag' | tagcolor"
         class="orb-tag-sink ">
         No tags were created
@@ -129,33 +105,33 @@
   </div>
 </ng-template>
 
-<ng-template #agentLastActivityTemplateCell let-row="row" let-value="value" let-i="index">
-  <div class="d-flex" *ngIf="row.state === 'new'">
+<ng-template #agentLastActivityTemplateCell let-i="index" let-row="row" let-value="value">
+  <div *ngIf="row.state === 'new'" class="d-flex">
     Never
   </div>
-  <div class="d-flex" *ngIf="row.state !== 'new'">
+  <div *ngIf="row.state !== 'new'" class="d-flex">
     {{ value | date:'short' }}
   </div>
 </ng-template>
 
-<ng-template #actionsTemplateCell let-row="row" let-value="value" let-i="index">
+<ng-template #actionsTemplateCell let-i="index" let-row="row" let-value="value">
   <div class="d-flex flex-row">
-    <button nbButton
-            ghost
+    <button (click)="openDetailsModal(row)"
             class="orb-action-hover detail-button"
-            (click)="openDetailsModal(row)">
+            ghost
+            nbButton>
       <nb-icon icon="search-outline"></nb-icon>
     </button>
-    <button nbButton
-            ghost
+    <button (click)="onOpenEdit(row)"
             class="orb-action-hover edit-button"
-            (click)="onOpenEdit(row)">
+            ghost
+            nbButton>
       <nb-icon icon="edit-outline"></nb-icon>
     </button>
-    <button nbButton
-            ghost
+    <button (click)="openDeleteModal(row)"
             class="orb-action-hover del-button"
-            (click)="openDeleteModal(row)">
+            ghost
+            nbButton>
       <nb-icon icon="trash-2-outline"></nb-icon>
     </button>
   </div>

--- a/ui/src/app/pages/fleet/agents/match/agent.match.component.html
+++ b/ui/src/app/pages/fleet/agents/match/agent.match.component.html
@@ -45,7 +45,7 @@
   <div class="d-flex">
     <mat-chip-list>
       <mat-chip
-          class="orb-tag-sink "
+          class="orb-tag-chip "
           *ngFor="let tag of value | keyvalue | slice:0:3"
           [style.background-color]="tag | tagcolor">
           {{tag | tagchip}}

--- a/ui/src/app/pages/fleet/agents/view/agent.view.component.html
+++ b/ui/src/app/pages/fleet/agents/view/agent.view.component.html
@@ -13,10 +13,10 @@
       <span *ngIf="agent?.state !== agentStates.new">
         Last activity
         <span *ngIf="isToday()">
-          today, at {{ agent?.ts_last_hb | date: 'mediumTime' }}
+          today, at {{ agent?.ts_last_hb | date: 'HH:mm z' }}
         </span>
         <span *ngIf="!isToday()">
-          on {{ agent?.ts_last_hb | date:'medium' }}
+          on {{ agent?.ts_last_hb | date: 'M/d/yy, HH:mm z' }}
         </span>
       </span>
       <span *ngIf="agent?.state === agentStates.new">
@@ -59,13 +59,13 @@
                 <mat-chip
                   *ngFor="let tag of agent?.orb_tags | keyvalue"
                   [style.background-color]="tag | tagcolor"
-                  class="orb-tag-sink">
+                  class="orb-tag-chip">
                   {{ tag | tagchip }}
                 </mat-chip>
                 <mat-chip
                   *ngFor="let tag of agent?.agent_tags | keyvalue"
                   [style.background-color]="tag | tagcolor"
-                  class="orb-tag-sink">
+                  class="orb-tag-chip">
                   {{tag | tagchip}}
                 </mat-chip>
               </mat-chip-list>

--- a/ui/src/app/pages/fleet/groups/add/agent.group.add.component.html
+++ b/ui/src/app/pages/fleet/groups/add/agent.group.add.component.html
@@ -78,7 +78,7 @@
                 <mat-chip
                   *ngFor="let tag of selectedTags | keyvalue"
                   [style.background-color]="tag | tagcolor"
-                  class="orb-tag-sink ">
+                  class="orb-tag-chip ">
                   {{tag | tagchip}}
                   <nb-icon (click)="onRemoveTag(tag.key)"
                            class="ml-1"
@@ -88,7 +88,7 @@
                 <mat-chip
                   *ngIf="(selectedTags | json) === '{}'"
                   [style.background-color]="'notag' | tagcolor"
-                  class="orb-tag-sink ">
+                  class="orb-tag-chip ">
                   No tag added
                 </mat-chip>
               </mat-chip-list>
@@ -213,13 +213,13 @@
                 <mat-chip
                   *ngFor="let tag of selectedTags | keyvalue"
                   [style.background-color]="tag | tagcolor"
-                  class="orb-tag-sink ">
+                  class="orb-tag-chip ">
                   {{tag | tagchip}}
                 </mat-chip>
                 <mat-chip
                   *ngIf="(selectedTags | json) === '{}'"
                   [style.background-color]="'notag' | tagcolor"
-                  class="orb-tag-sink ">
+                  class="orb-tag-chip ">
                   No tag added
                 </mat-chip>
               </mat-chip-list>
@@ -310,7 +310,7 @@
       <mat-chip
         *ngFor="let tag of value | keyvalue"
         [style.background-color]="tag | tagcolor"
-        class="orb-tag-sink ">
+        class="orb-tag-chip ">
         {{tag | tagchip}}
       </mat-chip>
     </mat-chip-list>
@@ -319,6 +319,6 @@
 
 <ng-template #agentLastHBTemplateCell let-i="index" let-row="row" let-value="value">
   <div>
-    {{ row.ts_last_hb | date: 'short' }}
+    {{ row.ts_last_hb | date: 'M/d/yy, HH:mm z' }}
   </div>
 </ng-template>

--- a/ui/src/app/pages/fleet/groups/details/agent.group.details.component.html
+++ b/ui/src/app/pages/fleet/groups/details/agent.group.details.component.html
@@ -30,7 +30,7 @@
         <div>
           <mat-chip-list>
             <mat-chip
-                class="orb-tag-sink "
+                class="orb-tag-chip "
                 *ngFor="let tag of agentGroup.tags | keyvalue"
                 [style.background-color]="tag | tagcolor">
                 {{tag | tagchip}}

--- a/ui/src/app/pages/fleet/groups/list/agent.group.list.component.html
+++ b/ui/src/app/pages/fleet/groups/list/agent.group.list.component.html
@@ -87,7 +87,7 @@
   <div class="d-flex">
     <mat-chip-list>
       <mat-chip
-          class="orb-tag-sink "
+          class="orb-tag-chip "
           *ngFor="let tag of value | keyvalue | slice:0:3"
           [style.background-color]="tag | tagcolor">
           {{tag | tagchip}}

--- a/ui/src/app/pages/fleet/groups/list/agent.group.list.component.html
+++ b/ui/src/app/pages/fleet/groups/list/agent.group.list.component.html
@@ -4,7 +4,7 @@
     </xng-breadcrumb>
     <h4>{{strings.list.header}}</h4>
   </header>
-  <div class="d-flex flex-column mt-4" #tableWrapper>
+  <div #tableWrapper class="d-flex flex-column mt-4">
     <div class="d-flex justify-content-between align-items-end mb-2">
       <div class="d-flex">
         <p *ngIf="paginationControls.data && paginationControls.data.length> 0"
@@ -19,101 +19,104 @@
       <div class="d-flex">
         <div class="mr-3">
           <nb-select
-            *ngIf="tableFilters && tableFilters.length"
-            [(selected)]="filterSelectedIndex"
             (selectedChange)="onFilterSelected($event)"
+            *ngIf="tableFilters && tableFilters.length"
+            [(selected)]="selectedFilter"
             appearance="filled"
-            size="medium"
             class="d-flex justify-content-end"
-            style="width: 160px; height: 100%"
-            placeholder="Filter by">
-            <nb-option *ngFor="let conf of tableFilters" [value]="conf.id">{{ conf.label }}</nb-option>
+            placeholder="Filter by"
+            size="medium"
+            style="width: 160px; height: 100%">
+            <nb-option *ngFor="let conf of tableFilters" [value]="conf">{{ conf.label }}</nb-option>
           </nb-select>
         </div>
-        <nb-form-field *ngIf="filterSelectedIndex =='1'">
-          <nb-icon nbPrefix icon="search-outline" pack="eva"></nb-icon>
-          <input nbInput
-                 (keyup)="getAgentGroups()"
+        <nb-form-field *ngIf="selectedFilter">
+          <nb-icon icon="search-outline" nbPrefix pack="eva"></nb-icon>
+          <input (input)="applyFilter()"
+                 [(ngModel)]="filterValue"
                  [placeholder]="searchPlaceholder"
-                 type="text"
                  fieldSize="medium"
-                 [(ngModel)]="paginationControls.tags"/>
-        </nb-form-field>
-        <nb-form-field *ngIf="filterSelectedIndex =='0'">
-          <nb-icon nbPrefix icon="search-outline" pack="eva"></nb-icon>
-          <input nbInput
-                 (keyup)="getAgentGroups()"
-                 [placeholder]="searchPlaceholder"
-                 type="text"
-                 fieldSize="medium"
-                 [(ngModel)]="paginationControls.name"/>
+                 nbInput
+                 type="text"/>
         </nb-form-field>
       </div>
     </div>
     <div class="add-agent-container">
-      <button nbButton
+      <button (click)="onOpenAdd()"
               ghost="true"
-              status="primary"
-              (click)="onOpenAdd()">
+              nbButton
+              status="primary">
         <i class="fa fa-plus">&nbsp;</i>{{strings.list.create}}</button>
     </div>
     <ngx-datatable
-        #table
-        class="orb"
-        style="height: calc(100vh - 300px)"
-        [loadingIndicator]="loading"
-        [externalPaging]="true"
-        [externalSorting]="true"
-        [count]="paginationControls.total"
-        [limit]="paginationControls.limit"
-        [offset]="paginationControls.offset"
-        [rows]="paginationControls.data"
-        [scrollbarV]="true"
-        (page)='getAgentGroups($event)'
-        [columns]="columns"
-        [columnMode]="columnMode.flex"
-        [headerHeight]="50"
-        [footerHeight]="50"
-        [rowHeight]="50">
+      #table
+      [columnMode]="columnMode.flex"
+      [columns]="columns"
+      [footerHeight]="50"
+      [headerHeight]="50"
+      [limit]="paginationControls.limit"
+      [loadingIndicator]="loading"
+      [rowHeight]="50"
+      [rows]="paginationControls.data"
+      [scrollbarV]="true"
+      [sorts]="tableSorts"
+      class="orb"
+      style="height: calc(62vh)">
     </ngx-datatable>
   </div>
 </div>
 
-<ng-template #agentGroupTemplateCell let-row="row">
-  <span class="matching-agents" (click)="onMatchingAgentsModal(row)">{{ row.matching_agents.total }}</span>
+<ng-template #agentGroupNameTemplateCell let-i="index" let-row="row" let-value="value">
+  <div nbTooltip="{{ row.id }}">
+    {{ row.name }}
+  </div>
 </ng-template>
 
-<ng-template #agentGroupTagsTemplateCell let-row="row" let-value="value" let-i="index">
-  <div class="d-flex">
-    <mat-chip-list>
+<ng-template #agentGroupTemplateCell let-row="row">
+  <span (click)="onMatchingAgentsModal(row)"
+        class="matching-agents"
+        nbTooltip="{{ row.matching_agents | json }}">
+    {{ row.matching_agents.total }}
+  </span>
+</ng-template>
+
+<ng-template #agentGroupTagsTemplateCell let-i="index" let-row="row" let-value="value">
+  <div class="d-block">
+    <mat-chip-list nbTooltip="{{ value | json }}">
       <mat-chip
-          class="orb-tag-chip "
-          *ngFor="let tag of value | keyvalue | slice:0:3"
-          [style.background-color]="tag | tagcolor">
-          {{tag | tagchip}}
+        *ngFor="let tag of value | keyvalue | slice:0:3"
+        [style.background-color]="tag | tagcolor"
+        class="orb-tag-chip ">
+        {{tag | tagchip}}
+      </mat-chip>
+      <mat-chip
+        *ngIf="(row?.tags | json) === '{}'"
+        [style.background-color]="'notag' | tagcolor"
+        class="orb-tag-chip ">
+        No tags were created
       </mat-chip>
     </mat-chip-list>
   </div>
 </ng-template>
 
-<ng-template #actionsTemplateCell let-row="row" let-value="value" let-i="index">
+<ng-template #actionsTemplateCell let-i="index" let-row="row" let-value="value">
   <div class="d-flex flex-row">
-    <button nbButton
-            ghost
+    <button (click)="openDetailsModal(row)"
             class="orb-action-hover detail-button"
-            (click)="openDetailsModal(row)">
+            ghost
+            nbButton>
       <nb-icon icon="search-outline"></nb-icon>
     </button>
-    <button nbButton
-            ghost
+    <button (click)="onOpenEdit(row)"
             class="orb-action-hover edit-button"
-            (click)="onOpenEdit(row)">
+            ghost
+            nbButton>
       <nb-icon icon="edit-outline"></nb-icon>
     </button>
-    <button nbButton
-            ghost
+    <button (click)="openDeleteModal(row)"
             class="orb-action-hover del-button"
-            (click)="openDeleteModal(row)">
+            ghost
+            nbButton>
       <nb-icon icon="trash-2-outline"></nb-icon>
     </button>
   </div>

--- a/ui/src/app/pages/fleet/groups/list/agent.group.list.component.ts
+++ b/ui/src/app/pages/fleet/groups/list/agent.group.list.component.ts
@@ -1,4 +1,12 @@
-import { AfterViewChecked, AfterViewInit, ChangeDetectorRef, Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import {
+  AfterViewChecked,
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  OnInit,
+  TemplateRef,
+  ViewChild,
+} from '@angular/core';
 import { NbDialogService } from '@nebular/theme';
 
 import { DropdownFilterItem } from 'app/common/interfaces/mainflux.interface';
@@ -10,7 +18,6 @@ import { ColumnMode, DatatableComponent, TableColumn } from '@swimlane/ngx-datat
 import { AgentGroupsService } from 'app/common/services/agents/agent.groups.service';
 import { NgxDatabalePageInfo, OrbPagination } from 'app/common/interfaces/orb/pagination.interface';
 import { AgentGroup } from 'app/common/interfaces/orb/agent.group.interface';
-import { Debounce } from 'app/shared/decorators/utils';
 import { AgentMatchComponent } from 'app/pages/fleet/agents/match/agent.match.component';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 
@@ -24,6 +31,7 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
   strings = STRINGS.agentGroups;
 
   columnMode = ColumnMode;
+
   columns: TableColumn[];
 
   loading = false;
@@ -31,11 +39,14 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
   paginationControls: OrbPagination<AgentGroup>;
 
   searchPlaceholder = 'Search by name';
-  filterSelectedIndex = '0';
 
   // templates
+  @ViewChild('agentGroupNameTemplateCell') agentGroupNameTemplateCell: TemplateRef<any>;
+
   @ViewChild('agentGroupTemplateCell') agentGroupsTemplateCell: TemplateRef<any>;
+
   @ViewChild('agentGroupTagsTemplateCell') agentGroupTagsTemplateCell: TemplateRef<any>;
+
   @ViewChild('actionsTemplateCell') actionsTemplateCell: TemplateRef<any>;
 
   tableFilters: DropdownFilterItem[] = [
@@ -44,14 +55,41 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
       label: 'Name',
       prop: 'name',
       selected: false,
+      filter: (agent, name) => agent?.name.includes(name),
     },
     {
       id: '1',
       label: 'Tags',
       prop: 'tags',
       selected: false,
+      filter: (agent, tag) => Object.entries(agent?.tags)
+        .filter(([key, value]) => `${ key }:${ value }`.includes(tag.replace(' ', ''))).length > 0,
+    },
+    {
+      id: '2',
+      label: 'Description',
+      prop: 'description',
+      selected: false,
+      filter: (agent, description) => agent?.description.includes(description),
     },
   ];
+
+  selectedFilter = this.tableFilters[0];
+
+  filterValue = null;
+
+  tableSorts = [
+    {
+      prop: 'name',
+      dir: 'asc',
+    },
+  ];
+
+  @ViewChild('tableWrapper') tableWrapper;
+
+  @ViewChild(DatatableComponent) table: DatatableComponent;
+
+  private currentComponentWidth;
 
   constructor(
     private cdr: ChangeDetectorRef,
@@ -65,9 +103,6 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
     this.paginationControls = AgentGroupsService.getDefaultPagination();
   }
 
-  @ViewChild('tableWrapper') tableWrapper;
-  @ViewChild(DatatableComponent) table: DatatableComponent;
-  private currentComponentWidth;
   ngAfterViewChecked() {
     if (this.table && this.table.recalculate && (this.tableWrapper.nativeElement.clientWidth !== this.currentComponentWidth)) {
       this.currentComponentWidth = this.tableWrapper.nativeElement.clientWidth;
@@ -79,7 +114,7 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
 
   ngOnInit() {
     this.agentGroupsService.clean();
-    this.getAgentGroups();
+    this.getAllAgentGroups();
   }
 
   ngAfterViewInit() {
@@ -87,9 +122,11 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
       {
         prop: 'name',
         name: 'Name',
+        canAutoResize: true,
         resizeable: false,
-        flexGrow: 1,
+        flexGrow: 2,
         minWidth: 90,
+        cellTemplate: this.agentGroupNameTemplateCell,
       },
       {
         prop: 'description',
@@ -102,22 +139,22 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
         prop: 'matching_agents',
         name: 'Agents',
         resizeable: false,
-        minWidth: 100,
+        minWidth: 25,
         flexGrow: 1,
         cellTemplate: this.agentGroupsTemplateCell,
       },
       {
         prop: 'tags',
         name: 'Tags',
-        minWidth: 90,
+        minWidth: 300,
         flexGrow: 3,
-        cellClass: Object,
+        resizeable: false,
         cellTemplate: this.agentGroupTagsTemplateCell,
       },
       {
         name: '',
         prop: 'actions',
-        minWidth: 130,
+        minWidth: 150,
         resizeable: false,
         sortable: false,
         flexGrow: 1,
@@ -128,21 +165,25 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
     this.cdr.detectChanges();
   }
 
-  @Debounce(500)
-  getAgentGroups(pageInfo: NgxDatabalePageInfo = null): void {
-    const isFilter = this.paginationControls.name?.length > 0 || this.paginationControls.tags?.length > 0;
+  getAllAgentGroups(): void {
+    this.agentGroupsService.getAllAgentGroups().subscribe(resp => {
+      this.paginationControls.data = resp.data;
+      this.paginationControls.total = resp.data.length;
+      this.paginationControls.offset = resp.offset / resp.limit;
+      this.loading = false;
+      this.cdr.markForCheck();
+    });
+  }
 
-    if (isFilter) {
-      pageInfo = {
-        offset: this.paginationControls.offset,
-        limit: this.paginationControls.limit,
-      };
-      if (this.paginationControls.name?.length > 0) pageInfo.name = this.paginationControls.name;
-      if (this.paginationControls.tags?.length > 0) pageInfo.tags = this.paginationControls.tags;
-    }
+  getAgentGroups(pageInfo: NgxDatabalePageInfo = null): void {
+    const finalPageInfo = { ...pageInfo };
+    finalPageInfo.dir = 'desc';
+    finalPageInfo.order = 'name';
+    finalPageInfo.limit = this.paginationControls.limit;
+    finalPageInfo.offset = pageInfo?.offset * pageInfo?.limit || 0;
 
     this.loading = true;
-    this.agentGroupsService.getAgentGroups(pageInfo, isFilter).subscribe(
+    this.agentGroupsService.getAgentGroups(pageInfo).subscribe(
       (resp: OrbPagination<AgentGroup>) => {
         this.paginationControls = resp;
         this.paginationControls.offset = pageInfo?.offset || 0;
@@ -165,8 +206,22 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
     });
   }
 
-  onFilterSelected(selectedIndex) {
-    this.searchPlaceholder = `Search by ${ this.tableFilters[selectedIndex].label }`;
+  onFilterSelected(filter) {
+    this.searchPlaceholder = `Search by ${ filter.label }`;
+    this.filterValue = null;
+  }
+
+  applyFilter() {
+    if (!this.paginationControls || !this.paginationControls?.data) return;
+
+    if (!this.filterValue || this.filterValue === '') {
+      this.table.rows = this.paginationControls.data;
+    } else {
+      this.table.rows = this.paginationControls.data.filter(sink => this.filterValue.split(/[,;]+/gm).reduce((prev, curr) => {
+        return this.selectedFilter.filter(sink, curr) && prev;
+      }, true));
+    }
+    this.paginationControls.offset = 0;
   }
 
   openDeleteModal(row: any) {
@@ -203,18 +258,11 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
 
   onMatchingAgentsModal(row: any) {
     this.dialogService.open(AgentMatchComponent, {
-      context: {agentGroup: row},
+      context: { agentGroup: row },
       autoFocus: true,
       closeOnEsc: true,
     }).onClose.subscribe(_ => {
       this.getAgentGroups();
-    });
-  }
-
-  searchAgentByName(input) {
-    this.getAgentGroups({
-      ...this.paginationControls,
-      [this.tableFilters[this.filterSelectedIndex].prop]: input,
     });
   }
 }

--- a/ui/src/app/pages/sinks/add/sink.add.component.html
+++ b/ui/src/app/pages/sinks/add/sink.add.component.html
@@ -184,7 +184,7 @@
                   *ngFor="let tag of this.selectedTags | keyvalue; index as i;"
                   [attr.data-orb-qa-id]="'tag_' + i"
                   [style.background-color]="tag | tagcolor"
-                  class="orb-tag-sink">
+                  class="orb-tag-chip">
                   {{tag | tagchip}}
                   <nb-icon (click)="onRemoveTag(tag.key)"
                            class="ml-1"
@@ -194,7 +194,7 @@
                 <mat-chip
                   *ngIf="(selectedTags | json) === '{}'"
                   [style.background-color]="'notag' | tagcolor"
-                  class="orb-tag-sink ">
+                  class="orb-tag-chip ">
                   No tag added
                 </mat-chip>
               </mat-chip-list>
@@ -326,13 +326,13 @@
                   *ngFor="let tag of selectedTags | keyvalue; index as i;"
                   [attr.data-orb-qa-id]="'review-tag_' + i"
                   [style.background-color]="tag | tagcolor"
-                  class="orb-tag-sink ">
+                  class="orb-tag-chip ">
                   {{tag | tagchip}}
                 </mat-chip>
                 <mat-chip
                   *ngIf="(selectedTags | json) === '{}'"
                   [style.background-color]="'notag' | tagcolor"
-                  class="orb-tag-sink ">
+                  class="orb-tag-chip ">
                   No tag added
                 </mat-chip>
               </mat-chip-list>

--- a/ui/src/app/pages/sinks/details/sink.details.component.html
+++ b/ui/src/app/pages/sinks/details/sink.details.component.html
@@ -42,7 +42,7 @@
         <div>
           <mat-chip-list style="min-width: 0.2pc; min-height: 0.2pc;">
             <mat-chip
-                class="orb-tag-sink "
+                class="orb-tag-chip "
                 *ngFor="let tag of sink.tags | keyvalue"
                 [style.background-color]="tag | tagcolor">
                 {{tag | tagchip}}

--- a/ui/src/app/pages/sinks/list/sink.list.component.html
+++ b/ui/src/app/pages/sinks/list/sink.list.component.html
@@ -4,7 +4,7 @@
     </xng-breadcrumb>
     <h4>{{strings.list.header}}</h4>
   </header>
-  <div class="d-flex flex-column mt-4" #tableWrapper>
+  <div #tableWrapper class="d-flex flex-column mt-4">
     <div class="d-flex justify-content-between align-items-end mb-2">
       <div class="d-flex">
         <p *ngIf=" paginationControls.data && paginationControls.data.length> 0"
@@ -20,113 +20,100 @@
       <div class="d-flex">
         <div class="mr-3">
           <nb-select
-            *ngIf="tableFilters && tableFilters.length"
-            [(selected)]="filterSelectedIndex"
             (selectedChange)="onFilterSelected($event)"
+            *ngIf="tableFilters && tableFilters.length"
+            [(selected)]="selectedFilter"
             appearance="filled"
-            size="medium"
             class="d-flex justify-content-end"
-            style="width: 160px; height: 100%"
-            placeholder="Filter by">
-            <nb-option *ngFor="let conf of tableFilters" [value]="conf.id">{{ conf.label }}</nb-option>
+            placeholder="Filter by"
+            size="medium"
+            style="width: 160px; height: 100%">
+            <nb-option *ngFor="let conf of tableFilters" [value]="conf">{{ conf.label }}</nb-option>
           </nb-select>
         </div>
-        <nb-form-field *ngIf="filterSelectedIndex =='1'">
-          <nb-icon nbPrefix icon="search-outline" pack="eva"></nb-icon>
-          <input nbInput
-                 (keyup)="getSinks()"
+        <nb-form-field *ngIf="selectedFilter">
+          <nb-icon icon="search-outline" nbPrefix pack="eva"></nb-icon>
+          <input (input)="applyFilter()"
+                 [(ngModel)]="filterValue"
                  [placeholder]="searchPlaceholder"
-                 type="text"
                  fieldSize="medium"
-                 [(ngModel)]="paginationControls.tags"/>
-        </nb-form-field>
-        <nb-form-field *ngIf="filterSelectedIndex =='0'">
-          <nb-icon nbPrefix icon="search-outline" pack="eva"></nb-icon>
-          <input nbInput
-                 (keyup)="getSinks()"
-                 [placeholder]="searchPlaceholder"
-                 type="text"
-                 fieldSize="medium"
-                 [(ngModel)]="paginationControls.name"/>
+                 nbInput
+                 type="text"/>
         </nb-form-field>
       </div>
     </div>
     <div class="add-sink-container">
-      <button nbButton
+      <button (click)="onOpenAdd()"
               ghost="true"
-              status="primary"
-              (click)="onOpenAdd()">
+              nbButton
+              status="primary">
         <i class="fa fa-plus">&nbsp;</i>{{strings.list.create}}</button>
     </div>
     <ngx-datatable
       #table
-      class="orb"
-      style="height: calc(100vh - 300px)"
-      [loadingIndicator]="loading"
-      [externalPaging]="true"
-      [externalSorting]="true"
-      [count]="paginationControls.total"
+      [columnMode]="columnMode.flex"
+      [columns]="columns"
+      [footerHeight]="50"
+      [headerHeight]="50"
       [limit]="paginationControls.limit"
-      [offset]="paginationControls.offset"
+      [loadingIndicator]="loading"
+      [rowHeight]="50"
       [rows]="paginationControls.data"
       [scrollbarV]="true"
-      (page)='getSinks($event)'
-      [columns]="columns"
-      [columnMode]="columnMode.flex"
-      [headerHeight]="50"
-      [footerHeight]="50"
-      [rowHeight]="50">
+      [sorts]="tableSorts"
+      class="orb"
+      style="height: calc(62vh)">
     </ngx-datatable>
   </div>
 </div>
 
-<ng-template #sinkStateTemplateCell let-row="row" let-value="value" let-i="index">
+<ng-template #sinkStateTemplateCell let-i="index" let-row="row" let-value="value">
   <div>
     <div *ngIf="row.state === 'active'">
-      <i class="fa fa-circle orb-service-active" style="color: #61f69f;"
-         aria-hidden="true"></i>
+      <i aria-hidden="true" class="fa fa-circle orb-service-active"
+         style="color: #61f69f;"></i>
       {{ row.state | titlecase }}
     </div>
     <div *ngIf="row.state !== 'active'">
-      <i class="fa fa-circle orb-service-inactive" style="color: #f2994a;"
-         aria-hidden="true"></i>
+      <i aria-hidden="true" class="fa fa-circle orb-service-inactive"
+         style="color: #f2994a;"></i>
       {{ row.state | titlecase }}
     </div>
   </div>
 </ng-template>
 
-<ng-template #sinkTagsTemplateCell let-row="row" let-value="value" let-i="index">
+<ng-template #sinkTagsTemplateCell let-i="index" let-row="row" let-value="value">
   <div class="d-flex">
     <mat-chip-list>
       <mat-chip
-          class="orb-tag-sink "
-          *ngFor="let tag of value | keyvalue | slice:0:3"
-          [style.background-color]="tag | tagcolor">
-          {{tag | tagchip}}
+        *ngFor="let tag of value | keyvalue | slice:0:3"
+        [style.background-color]="tag | tagcolor"
+        class="orb-tag-sink ">
+        {{tag | tagchip}}
       </mat-chip>
     </mat-chip-list>
   </div>
 </ng-template>
 
-<ng-template #sinkActionsTemplateCell let-row="row" let-value="value" let-i="index">
+<ng-template #sinkActionsTemplateCell let-i="index" let-row="row" let-value="value">
 
   <div class="d-flex flex-row">
-    <button nbButton
-            ghost
+    <button (click)="openDetailsModal(row)"
             class="orb-action-hover detail-button"
-            (click)="openDetailsModal(row)">
+            ghost
+            nbButton>
       <nb-icon icon="search-outline"></nb-icon>
     </button>
-    <button nbButton
-            ghost
+    <button (click)="onOpenEdit(row)"
             class="orb-action-hover edit-button"
-            (click)="onOpenEdit(row)">
+            ghost
+            nbButton>
       <nb-icon icon="edit-outline"></nb-icon>
     </button>
-    <button nbButton
-            ghost
+    <button (click)="openDeleteModal(row)"
             class="orb-action-hover del-button"
-            (click)="openDeleteModal(row)">
+            ghost
+            nbButton>
       <nb-icon icon="trash-2-outline"></nb-icon>
     </button>
   </div>

--- a/ui/src/app/pages/sinks/list/sink.list.component.html
+++ b/ui/src/app/pages/sinks/list/sink.list.component.html
@@ -81,13 +81,19 @@
 </ng-template>
 
 <ng-template #sinkTagsTemplateCell let-i="index" let-row="row" let-value="value">
-  <div class="d-flex">
+  <div class="d-block">
     <mat-chip-list nbTooltip="{{ value | json }}">
       <mat-chip
         *ngFor="let tag of value | keyvalue | slice:0:3"
         [style.background-color]="tag | tagcolor"
-        class="orb-tag-sink ">
+        class="orb-tag-chip ">
         {{tag | tagchip}}
+      </mat-chip>
+      <mat-chip
+        *ngIf="(row?.tags | json) === '{}'"
+        [style.background-color]="'notag' | tagcolor"
+        class="orb-tag-chip ">
+        No tags were created
       </mat-chip>
     </mat-chip-list>
   </div>

--- a/ui/src/app/pages/sinks/list/sink.list.component.html
+++ b/ui/src/app/pages/sinks/list/sink.list.component.html
@@ -67,24 +67,22 @@
   </div>
 </div>
 
+<ng-template #sinkNameTemplateCell let-i="index" let-row="row" let-value="value">
+  <div nbTooltip="{{ row.id }}">
+    {{ row.name }}
+  </div>
+</ng-template>
+
 <ng-template #sinkStateTemplateCell let-i="index" let-row="row" let-value="value">
   <div>
-    <div *ngIf="row.state === 'active'">
-      <i aria-hidden="true" class="fa fa-circle orb-service-active"
-         style="color: #61f69f;"></i>
+      <i aria-hidden="true" class="fa fa-circle orb-service-{{ row.state }}"></i>
       {{ row.state | titlecase }}
-    </div>
-    <div *ngIf="row.state !== 'active'">
-      <i aria-hidden="true" class="fa fa-circle orb-service-inactive"
-         style="color: #f2994a;"></i>
-      {{ row.state | titlecase }}
-    </div>
   </div>
 </ng-template>
 
 <ng-template #sinkTagsTemplateCell let-i="index" let-row="row" let-value="value">
   <div class="d-flex">
-    <mat-chip-list>
+    <mat-chip-list nbTooltip="{{ value | json }}">
       <mat-chip
         *ngFor="let tag of value | keyvalue | slice:0:3"
         [style.background-color]="tag | tagcolor"

--- a/ui/src/app/pages/sinks/list/sink.list.component.scss
+++ b/ui/src/app/pages/sinks/list/sink.list.component.scss
@@ -128,3 +128,15 @@ tr div p {
     right: 5px;
   }
 }
+
+.orb-service- {
+  &active {
+    color: #6fcf97;
+  }
+  &unknown {
+    color: #f2994a;
+  }
+  &error {
+    color: #df316f;
+  }
+}

--- a/ui/src/app/pages/sinks/list/sink.list.component.ts
+++ b/ui/src/app/pages/sinks/list/sink.list.component.ts
@@ -1,4 +1,12 @@
-import { AfterViewChecked, AfterViewInit, ChangeDetectorRef, Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import {
+  AfterViewChecked,
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  OnInit,
+  TemplateRef,
+  ViewChild,
+} from '@angular/core';
 import { NbDialogService } from '@nebular/theme';
 
 import { DropdownFilterItem } from 'app/common/interfaces/mainflux.interface';
@@ -8,8 +16,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { STRINGS } from 'assets/text/strings';
 import { ColumnMode, DatatableComponent, TableColumn } from '@swimlane/ngx-datatable';
 import { NgxDatabalePageInfo, OrbPagination } from 'app/common/interfaces/orb/pagination.interface';
-import { AgentGroup } from 'app/common/interfaces/orb/agent.group.interface';
-import { Debounce } from 'app/shared/decorators/utils';
 import { SinkDeleteComponent } from 'app/pages/sinks/delete/sink.delete.component';
 import { Sink } from 'app/common/interfaces/orb/sink.interface';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
@@ -23,18 +29,21 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
   strings = STRINGS.sink;
 
   columnMode = ColumnMode;
+
   columns: TableColumn[];
 
   loading = false;
 
-  paginationControls: OrbPagination<AgentGroup>;
+  paginationControls: OrbPagination<Sink>;
 
   searchPlaceholder = 'Search by name';
-  filterSelectedIndex = '0';
+
 
   // templates
   @ViewChild('sinkStateTemplateCell') sinkStateTemplateCell: TemplateRef<any>;
+
   @ViewChild('sinkTagsTemplateCell') sinkTagsTemplateCell: TemplateRef<any>;
+
   @ViewChild('sinkActionsTemplateCell') actionsTemplateCell: TemplateRef<any>;
 
   tableFilters: DropdownFilterItem[] = [
@@ -43,14 +52,55 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
       label: 'Name',
       prop: 'name',
       selected: false,
+      filter: (sink, name) => sink?.name.includes(name),
     },
     {
       id: '1',
       label: 'Tags',
       prop: 'tags',
       selected: false,
+      filter: (sink, tag) => Object.entries(sink?.tags)
+        .filter(([key, value]) => key?.includes(tag) || (!!value && value as string).includes(tag)).length > 0,
+    },
+    {
+      id: '2',
+      label: 'Description',
+      prop: 'description',
+      selected: false,
+      filter: (sink, description) => sink?.description.includes(description),
+    },
+    {
+      id: '3',
+      label: 'Type',
+      prop: 'backend',
+      selected: false,
+      filter: (sink, backend) => sink?.backend.includes(backend),
+    },
+    {
+      id: '4',
+      label: 'Status',
+      prop: 'state',
+      selected: false,
+      filter: (sink, state) => sink?.state.includes(state),
     },
   ];
+
+  selectedFilter = this.tableFilters[0];
+
+  filterValue = null;
+
+  tableSorts = [
+    {
+      prop: 'name',
+      dir: 'asc',
+    },
+  ];
+
+  @ViewChild('tableWrapper') tableWrapper;
+
+  @ViewChild(DatatableComponent) table: DatatableComponent;
+
+  private currentComponentWidth;
 
   constructor(
     private cdr: ChangeDetectorRef,
@@ -64,21 +114,16 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
     this.paginationControls = SinksService.getDefaultPagination();
   }
 
-  @ViewChild('tableWrapper') tableWrapper;
-  @ViewChild(DatatableComponent) table: DatatableComponent;
-  private currentComponentWidth;
   ngAfterViewChecked() {
     if (this.table && this.table.recalculate && (this.tableWrapper.nativeElement.clientWidth !== this.currentComponentWidth)) {
       this.currentComponentWidth = this.tableWrapper.nativeElement.clientWidth;
       this.table.recalculate();
-      this.cdr.detectChanges();
-      window.dispatchEvent(new Event('resize'));
     }
   }
 
   ngOnInit() {
     this.sinkService.clean();
-    this.getSinks();
+    this.getAllSinks();
   }
 
   ngAfterViewInit() {
@@ -86,8 +131,9 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
       {
         prop: 'name',
         name: 'Name',
+        canAutoResize: true,
         resizeable: false,
-        flexGrow: 1,
+        flexGrow: 2,
         minWidth: 90,
       },
       {
@@ -117,6 +163,7 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
         name: 'Tags',
         minWidth: 90,
         flexGrow: 3,
+        resizeable: false,
         cellTemplate: this.sinkTagsTemplateCell,
       },
       {
@@ -133,27 +180,37 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
     this.cdr.detectChanges();
   }
 
+  getAllSinks(): void {
+    this.sinkService.getAllSinks().subscribe(resp => {
+      this.paginationControls.data = resp.data;
+      this.paginationControls.total = resp.data.length;
+      this.paginationControls.offset = resp.offset / resp.limit;
+      this.loading = false;
+      this.cdr.markForCheck();
+    });
+  }
 
-  @Debounce(500)
   getSinks(pageInfo: NgxDatabalePageInfo = null): void {
     const isFilter = this.paginationControls.name?.length > 0 || this.paginationControls.tags?.length > 0;
+    const finalPageInfo = { ...pageInfo };
+    finalPageInfo.dir = 'desc';
+    finalPageInfo.order = 'name';
+    finalPageInfo.limit = this.paginationControls.limit;
+    finalPageInfo.offset = pageInfo?.offset * pageInfo?.limit || 0;
 
     if (isFilter) {
-      pageInfo = {
-        offset: this.paginationControls.offset,
-        limit: this.paginationControls.limit,
-      };
-      if (this.paginationControls.name?.length > 0) pageInfo.name = this.paginationControls.name;
-      if (this.paginationControls.tags?.length > 0) pageInfo.tags = this.paginationControls.tags;
+      if (this.paginationControls.name?.length > 0) finalPageInfo.name = this.paginationControls.name;
+      if (this.paginationControls.tags?.length > 0) finalPageInfo.tags = this.paginationControls.tags;
     }
 
     this.loading = true;
-    this.sinkService.getSinks(pageInfo, isFilter).subscribe(
+    this.sinkService.getSinks(finalPageInfo, isFilter).subscribe(
       (resp: OrbPagination<Sink>) => {
-        this.paginationControls = resp;
-        this.paginationControls.offset = pageInfo?.offset || 0;
+        this.paginationControls.data = resp.data.slice(resp.offset, resp.offset + resp.limit);
         this.paginationControls.total = resp.total;
+        this.paginationControls.offset = resp.offset / resp.limit;
         this.loading = false;
+        this.cdr.detectChanges();
       },
     );
   }
@@ -161,28 +218,42 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
   onOpenAdd() {
     this.router.navigate(
       ['add'],
-      {relativeTo: this.route},
+      { relativeTo: this.route },
     );
   }
 
   onOpenEdit(sink: any) {
     this.router.navigate(
-      [`edit/${sink.id}`],
+      [`edit/${ sink.id }`],
       {
         relativeTo: this.route,
-        state: {sink: sink, edit: true},
+        state: { sink: sink, edit: true },
       },
     );
   }
 
-  onFilterSelected(selectedIndex) {
-    this.searchPlaceholder = `Search by ${this.tableFilters[selectedIndex].label}`;
+  onFilterSelected(filter) {
+    this.searchPlaceholder = `Search by ${ filter.label }`;
+    this.filterValue = null;
+  }
+
+  applyFilter() {
+    if (!this.paginationControls || !this.paginationControls?.data) return;
+
+    if (!this.filterValue || this.filterValue === '') {
+      this.table.rows = this.paginationControls.data;
+    } else {
+      this.table.rows = this.paginationControls.data.filter(sink => this.filterValue.split(/[\s,.:]+/gm).reduce((prev, curr) => {
+        return this.selectedFilter.filter(sink, curr) && prev;
+      }, true));
+    }
+
   }
 
   openDeleteModal(row: any) {
-    const {id} = row;
+    const { id } = row;
     this.dialogService.open(SinkDeleteComponent, {
-      context: {sink: row},
+      context: { sink: row },
       autoFocus: true,
       closeOnEsc: true,
     }).onClose.subscribe(
@@ -199,7 +270,7 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
 
   openDetailsModal(row: any) {
     this.dialogService.open(SinkDetailsComponent, {
-      context: {sink: row},
+      context: { sink: row },
       autoFocus: true,
       closeOnEsc: true,
     }).onClose.subscribe((resp) => {
@@ -208,13 +279,6 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
       } else {
         this.getSinks();
       }
-    });
-  }
-
-  searchSinkItemByName(input) {
-    this.getSinks({
-      ...this.paginationControls,
-      [this.tableFilters[this.filterSelectedIndex].prop]: input,
     });
   }
 

--- a/ui/src/app/pages/sinks/list/sink.list.component.ts
+++ b/ui/src/app/pages/sinks/list/sink.list.component.ts
@@ -62,7 +62,7 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
       prop: 'tags',
       selected: false,
       filter: (sink, tag) => Object.entries(sink?.tags)
-        .filter(([key, value]) => key?.includes(tag) || (!!value && value as string).includes(tag)).length > 0,
+        .filter(([key, value]) => `${key}:${value}`.includes(tag.replace(' ', ''))).length > 0,
     },
     {
       id: '2',
@@ -241,7 +241,8 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
     if (!this.filterValue || this.filterValue === '') {
       this.table.rows = this.paginationControls.data;
     } else {
-      this.table.rows = this.paginationControls.data.filter(sink => this.filterValue.split(/[\s,.:]+/gm).reduce((prev, curr) => {
+      this.table.rows = this.paginationControls.data.
+      filter(sink => this.filterValue.split(/[,;]+/gm).reduce((prev, curr) => {
         return this.selectedFilter.filter(sink, curr) && prev;
       }, true));
     }

--- a/ui/src/app/pages/sinks/list/sink.list.component.ts
+++ b/ui/src/app/pages/sinks/list/sink.list.component.ts
@@ -40,6 +40,8 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
 
 
   // templates
+  @ViewChild('sinkNameTemplateCell') sinkNameTemplateCell: TemplateRef<any>;
+
   @ViewChild('sinkStateTemplateCell') sinkStateTemplateCell: TemplateRef<any>;
 
   @ViewChild('sinkTagsTemplateCell') sinkTagsTemplateCell: TemplateRef<any>;
@@ -118,6 +120,8 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
     if (this.table && this.table.recalculate && (this.tableWrapper.nativeElement.clientWidth !== this.currentComponentWidth)) {
       this.currentComponentWidth = this.tableWrapper.nativeElement.clientWidth;
       this.table.recalculate();
+      this.cdr.detectChanges();
+      window.dispatchEvent(new Event('resize'));
     }
   }
 
@@ -135,6 +139,7 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
         resizeable: false,
         flexGrow: 2,
         minWidth: 90,
+        cellTemplate: this.sinkNameTemplateCell,
       },
       {
         prop: 'description',
@@ -161,7 +166,7 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
       {
         prop: 'tags',
         name: 'Tags',
-        minWidth: 90,
+        minWidth: 300,
         flexGrow: 3,
         resizeable: false,
         cellTemplate: this.sinkTagsTemplateCell,
@@ -191,26 +196,19 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
   }
 
   getSinks(pageInfo: NgxDatabalePageInfo = null): void {
-    const isFilter = this.paginationControls.name?.length > 0 || this.paginationControls.tags?.length > 0;
     const finalPageInfo = { ...pageInfo };
     finalPageInfo.dir = 'desc';
     finalPageInfo.order = 'name';
     finalPageInfo.limit = this.paginationControls.limit;
     finalPageInfo.offset = pageInfo?.offset * pageInfo?.limit || 0;
 
-    if (isFilter) {
-      if (this.paginationControls.name?.length > 0) finalPageInfo.name = this.paginationControls.name;
-      if (this.paginationControls.tags?.length > 0) finalPageInfo.tags = this.paginationControls.tags;
-    }
-
     this.loading = true;
-    this.sinkService.getSinks(finalPageInfo, isFilter).subscribe(
+    this.sinkService.getSinks(finalPageInfo).subscribe(
       (resp: OrbPagination<Sink>) => {
         this.paginationControls.data = resp.data.slice(resp.offset, resp.offset + resp.limit);
         this.paginationControls.total = resp.total;
         this.paginationControls.offset = resp.offset / resp.limit;
         this.loading = false;
-        this.cdr.detectChanges();
       },
     );
   }
@@ -247,7 +245,7 @@ export class SinkListComponent implements OnInit, AfterViewInit, AfterViewChecke
         return this.selectedFilter.filter(sink, curr) && prev;
       }, true));
     }
-
+    this.paginationControls.offset = 0;
   }
 
   openDeleteModal(row: any) {

--- a/ui/src/app/shared/components/table/table.component.html
+++ b/ui/src/app/shared/components/table/table.component.html
@@ -50,7 +50,7 @@
         <div *ngSwitchCase="'tags'">
           <mat-chip-list>
             <mat-chip
-                class="orb-tag-sink "
+                class="orb-tag-chip "
                 *ngFor="let tag of row[key] | keyvalue">
               <span class="align-content-center" style="font-size: 11px;">{{tag.key}}, {{tag.value}}</span>
             </mat-chip>

--- a/ui/src/app/shared/components/table/table.component.scss
+++ b/ui/src/app/shared/components/table/table.component.scss
@@ -74,7 +74,7 @@ $orb-primary-inactive: #969fb9;
     }
   }
 
-  .orb-tag-sink {
+  .orb-tag-chip {
     background: $orb-primary;
     color: $orb-white;
   }


### PR DESCRIPTION
* filter on client side

* sort client side

* tag filtering by key and value - try multiple keywords

* dynamic pagination and virtual scroll enabled

* table height and width with better fluidness

* some columns now have tooltips

* all services now offer convenience method to query and cache all pages of data
** agents, agent groups, sinks, datasets and policies.

* css improvements on table elements and table pages

* code style fixes

