### PR TITLE
fix(policy): set version number to display zero after creating

### DIFF
--- a/policies/api/http/responses.go
+++ b/policies/api/http/responses.go
@@ -20,7 +20,7 @@ type policyRes struct {
 	Policy        types.Metadata `json:"policy,omitempty"`
 	Format        string         `json:"format,omitempty"`
 	PolicyData    string         `json:"policy_data,omitempty"`
-	Version       int32          `json:"version,omitempty"`
+	Version       int32          `json:"version"`
 	LastModified  time.Time      `json:"ts_last_modified"`
 	created       bool
 }


### PR DESCRIPTION
Today, if a policy is created, the version number is empty until editing the policy. By this change, it will start at zero right after creating