### PR TITLE
fix(orb-ui): move click event listener to button container

### DIFF
--- a/ui/src/app/shared/components/orb/agent/provisioning/agent-provisioning.component.html
+++ b/ui/src/app/shared/components/orb/agent/provisioning/agent-provisioning.component.html
@@ -31,9 +31,9 @@
           <button
             [cdkCopyToClipboard]="command2copy"
             ghost="true"
+            (click)="toggleIcon('command')"
             nbButton>
-            <nb-icon (click)="toggleIcon('command')"
-                     [icon]="copyCommandIcon"
+            <nb-icon [icon]="copyCommandIcon"
                      pack="eva">
             </nb-icon>
           </button>


### PR DESCRIPTION
move click event listener to button container, parent of icon which was currently listening on click event