### PR TITLE
wrong text for policies, menu without children, key value as tags

### DIFF
--- a/ui/src/app/pages/pages-menu.ts
+++ b/ui/src/app/pages/pages-menu.ts
@@ -7,20 +7,16 @@ export const MENU: NbMenuItem[] = [
     icon: 'layout-outline',
     link: 'home',
     home: true,
+},
+  {
+    title: 'Agents',
+    icon: 'pin-outline',
+    link: 'fleet/agents',
   },
   {
-    title: 'Fleet Management',
-    icon: 'cube-outline',
-    children: [
-      {
-        title: 'Agents',
-        link: 'fleet/agents',
-      },
-      {
-        title: 'Agent Groups',
-        link: 'fleet/groups',
-      },
-    ],
+    title: 'Agent Groups',
+    icon: 'globe-outline',
+    link: 'fleet/groups',
   },
   {
     title: 'Policy Management',

--- a/ui/src/app/shared/components/orb/agent/agent-information/agent-information.component.html
+++ b/ui/src/app/shared/components/orb/agent/agent-information/agent-information.component.html
@@ -22,7 +22,7 @@
       <span class="float-right">{{ agent?.channel_id }}</span>
     </p>
     <div>
-      <label>Key Value Pairs</label>
+      <label>Tags</label>
       <div class="d-flex">
         <mat-chip-list>
           <mat-chip

--- a/ui/src/app/shared/components/orb/policy/policy-groups/policy-groups.component.ts
+++ b/ui/src/app/shared/components/orb/policy/policy-groups/policy-groups.component.ts
@@ -63,7 +63,7 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
     const groupsIds = datasets.map(dataset => dataset.agent_group_id);
 
     if (!groupsIds || groupsIds.length === 0) {
-      this.errors['nogroup'] = 'This agent does not belong to any group.';
+      this.errors['nogroup'] = 'This policy is not in use by any agent group.';
     }
 
     return forkJoin(groupsIds.map(id => this.groupService.getAgentGroupById(id))).map(groups => {


### PR DESCRIPTION
Fix wrong text for policy without groups linked, move agents and groups outside of fleet and name key values pair as tag on agents view to maintain the pattern of Orb