### PR TITLE
feat(orb-ui): #1105 show matching agents for agent group in policy view

### DIFF
--- a/ui/src/app/pages/fleet/groups/list/agent.group.list.component.ts
+++ b/ui/src/app/pages/fleet/groups/list/agent.group.list.component.ts
@@ -7,19 +7,18 @@ import {
   TemplateRef,
   ViewChild,
 } from '@angular/core';
-import { NbDialogService } from '@nebular/theme';
+import {NbDialogService} from '@nebular/theme';
 
-import { DropdownFilterItem } from 'app/common/interfaces/mainflux.interface';
-import { ActivatedRoute, Router } from '@angular/router';
-import { STRINGS } from 'assets/text/strings';
-import { AgentGroupDeleteComponent } from 'app/pages/fleet/groups/delete/agent.group.delete.component';
-import { AgentGroupDetailsComponent } from 'app/pages/fleet/groups/details/agent.group.details.component';
-import { ColumnMode, DatatableComponent, TableColumn } from '@swimlane/ngx-datatable';
-import { AgentGroupsService } from 'app/common/services/agents/agent.groups.service';
-import { NgxDatabalePageInfo, OrbPagination } from 'app/common/interfaces/orb/pagination.interface';
-import { AgentGroup } from 'app/common/interfaces/orb/agent.group.interface';
-import { AgentMatchComponent } from 'app/pages/fleet/agents/match/agent.match.component';
-import { NotificationsService } from 'app/common/services/notifications/notifications.service';
+import {DropdownFilterItem} from 'app/common/interfaces/mainflux.interface';
+import {ActivatedRoute, Router} from '@angular/router';
+import {STRINGS} from 'assets/text/strings';
+import {AgentGroupDeleteComponent} from 'app/pages/fleet/groups/delete/agent.group.delete.component';
+import {ColumnMode, DatatableComponent, TableColumn} from '@swimlane/ngx-datatable';
+import {AgentGroupsService} from 'app/common/services/agents/agent.groups.service';
+import {NgxDatabalePageInfo, OrbPagination} from 'app/common/interfaces/orb/pagination.interface';
+import {AgentGroup} from 'app/common/interfaces/orb/agent.group.interface';
+import {AgentMatchComponent} from 'app/pages/fleet/agents/match/agent.match.component';
+import {NotificationsService} from 'app/common/services/notifications/notifications.service';
 
 
 @Component({
@@ -63,7 +62,7 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
       prop: 'tags',
       selected: false,
       filter: (agent, tag) => Object.entries(agent?.tags)
-        .filter(([key, value]) => `${ key }:${ value }`.includes(tag.replace(' ', ''))).length > 0,
+          .filter(([key, value]) => `${key}:${value}`.includes(tag.replace(' ', ''))).length > 0,
     },
     {
       id: '2',
@@ -92,12 +91,12 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
   private currentComponentWidth;
 
   constructor(
-    private cdr: ChangeDetectorRef,
-    private dialogService: NbDialogService,
-    private agentGroupsService: AgentGroupsService,
-    private notificationsService: NotificationsService,
-    private route: ActivatedRoute,
-    private router: Router,
+      private cdr: ChangeDetectorRef,
+      private dialogService: NbDialogService,
+      private agentGroupsService: AgentGroupsService,
+      private notificationsService: NotificationsService,
+      private route: ActivatedRoute,
+      private router: Router,
   ) {
     this.paginationControls = AgentGroupsService.getDefaultPagination();
   }
@@ -150,11 +149,11 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
         resizeable: false,
         cellTemplate: this.agentGroupTagsTemplateCell,
         comparator: (a, b) => Object.entries(a)
-          .map(([key, value]) => `${key}:${value}`)
-          .join(',')
-          .localeCompare(Object.entries(b)
             .map(([key, value]) => `${key}:${value}`)
-            .join(',')),
+            .join(',')
+            .localeCompare(Object.entries(b)
+                .map(([key, value]) => `${key}:${value}`)
+                .join(',')),
       },
       {
         name: '',
@@ -182,7 +181,7 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
   }
 
   getAgentGroups(pageInfo: NgxDatabalePageInfo = null): void {
-    const finalPageInfo = { ...pageInfo };
+    const finalPageInfo = {...pageInfo};
     finalPageInfo.dir = 'desc';
     finalPageInfo.order = 'name';
     finalPageInfo.limit = this.paginationControls.limit;
@@ -190,12 +189,12 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
 
     this.loading = true;
     this.agentGroupsService.getAgentGroups(pageInfo).subscribe(
-      (resp: OrbPagination<AgentGroup>) => {
-        this.paginationControls = resp;
-        this.paginationControls.offset = pageInfo?.offset || 0;
-        this.paginationControls.total = resp.total;
-        this.loading = false;
-      },
+        (resp: OrbPagination<AgentGroup>) => {
+          this.paginationControls = resp;
+          this.paginationControls.offset = pageInfo?.offset || 0;
+          this.paginationControls.total = resp.total;
+          this.loading = false;
+        },
     );
   }
 
@@ -206,14 +205,14 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
   }
 
   onOpenEdit(agentGroup: any) {
-    this.router.navigate([`edit/${ agentGroup.id }`], {
-      state: { agentGroup: agentGroup, edit: true },
+    this.router.navigate([`edit/${agentGroup.id}`], {
+      state: {agentGroup: agentGroup, edit: true},
       relativeTo: this.route,
     });
   }
 
   onFilterSelected(filter) {
-    this.searchPlaceholder = `Search by ${ filter.label }`;
+    this.searchPlaceholder = `Search by ${filter.label}`;
     this.filterValue = null;
   }
 
@@ -231,40 +230,26 @@ export class AgentGroupListComponent implements OnInit, AfterViewInit, AfterView
   }
 
   openDeleteModal(row: any) {
-    const { name, id } = row;
+    const {name, id} = row;
     this.dialogService.open(AgentGroupDeleteComponent, {
-      context: { name },
+      context: {name},
       autoFocus: true,
       closeOnEsc: true,
     }).onClose.subscribe(
-      confirm => {
-        if (confirm) {
-          this.agentGroupsService.deleteAgentGroup(id).subscribe(() => {
-            this.notificationsService.success('Agent Group successfully deleted', '');
-            this.getAllAgentGroups();
-          });
-        }
-      },
+        confirm => {
+          if (confirm) {
+            this.agentGroupsService.deleteAgentGroup(id).subscribe(() => {
+              this.notificationsService.success('Agent Group successfully deleted', '');
+              this.getAllAgentGroups();
+            });
+          }
+        },
     );
-  }
-
-  openDetailsModal(row: any) {
-    this.dialogService.open(AgentGroupDetailsComponent, {
-      context: { agentGroup: row },
-      autoFocus: true,
-      closeOnEsc: true,
-    }).onClose.subscribe((resp) => {
-      if (resp) {
-        this.onOpenEdit(row);
-      } else {
-        this.getAllAgentGroups();
-      }
-    });
   }
 
   onMatchingAgentsModal(row: any) {
     this.dialogService.open(AgentMatchComponent, {
-      context: { agentGroup: row },
+      context: {agentGroup: row},
       autoFocus: true,
       closeOnEsc: true,
     }).onClose.subscribe(_ => {

--- a/ui/src/app/shared/components/orb/policy/policy-groups/policy-groups.component.html
+++ b/ui/src/app/shared/components/orb/policy/policy-groups/policy-groups.component.html
@@ -1,11 +1,13 @@
 <nb-card>
-  <nb-card-header>Active Groups</nb-card-header>
+  <nb-card-header>Assigned Groups</nb-card-header>
   <nb-card-body>
     <div *ngIf="!isLoading">
-      <button (click)="showAgentGroupDetail(group)"
+      <button (click)="showAgentGroupMatches(group)"
               *ngFor="let group of groups; last as isLast"
+              nbButton
+              nbTooltip="{{group.matching_agents.online}} online out of {{group.matching_agents.total}} agent(s)"
               class='agent-group-button'>
-        <span class="agent-group-accent">{{ group.name }}</span>
+        <span class="agent-group-accent">{{ group.name }}({{ group.matching_agents.online}})</span>
         <span *ngIf="!isLast">,</span>
       </button>
     </div>

--- a/ui/src/app/shared/components/orb/policy/policy-groups/policy-groups.component.scss
+++ b/ui/src/app/shared/components/orb/policy/policy-groups/policy-groups.component.scss
@@ -130,7 +130,7 @@ nb-card {
 .agent-group-accent {
   color: #c3c6cf !important;
   text-decoration: underline !important;
-  font-weight: bold;
+  font-weight: 600;
 }
 
 .error-accent {

--- a/ui/src/app/shared/components/orb/policy/policy-groups/policy-groups.component.ts
+++ b/ui/src/app/shared/components/orb/policy/policy-groups/policy-groups.component.ts
@@ -9,6 +9,7 @@ import { forkJoin, Subscription } from 'rxjs';
 import { AgentGroupDetailsComponent } from 'app/pages/fleet/groups/details/agent.group.details.component';
 import { NbDialogService } from '@nebular/theme';
 import { ActivatedRoute, Router } from '@angular/router';
+import {AgentMatchComponent} from 'app/pages/fleet/agents/match/agent.match.component';
 
 @Component({
   selector: 'ngx-policy-groups',
@@ -83,6 +84,14 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
       if (resp) {
         this.onOpenEditAgentGroup(agentGroup);
       }
+    });
+  }
+
+  showAgentGroupMatches(agentGroup) {
+    this.dialogService.open(AgentMatchComponent, {
+      context: { agentGroup },
+      autoFocus: true,
+      closeOnEsc: true,
     });
   }
 

--- a/ui/src/app/shared/shared.module.ts
+++ b/ui/src/app/shared/shared.module.ts
@@ -13,7 +13,7 @@ import {
   NbIconModule,
   NbInputModule,
   NbListModule,
-  NbSelectModule,
+  NbSelectModule, NbTooltipModule,
 } from '@nebular/theme';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
@@ -71,6 +71,7 @@ import { NgxDatatableModule } from '@swimlane/ngx-datatable';
     ClipboardModule,
     MatTooltipModule,
     NgxDatatableModule,
+    NbTooltipModule,
   ],
   declarations: [
     ConfirmationComponent,


### PR DESCRIPTION
* add tooltip displaying online and total agents for group when hovering group name

* open matching agents list dialog when clicking on agent group name

* shows number of online agents in parenthesis - i.e.: 'agent_group_name(3)' for 3 online agents

* change card title to 'Assigned Groups'

![image](https://user-images.githubusercontent.com/1490938/165394761-372b7e6c-0b66-4406-a12b-0545840f581f.png)


latest UI on Figma I believe
![image](https://user-images.githubusercontent.com/1490938/165394922-6d281664-4dc5-4549-aac8-abb50a26932e.png)
