### PR TITLE
fix(orb-ui): rollback dataset-from rule for showing agent_group_id

### DIFF
--- a/ui/src/app/pages/datasets/dataset-from/dataset-from.component.html
+++ b/ui/src/app/pages/datasets/dataset-from/dataset-from.component.html
@@ -15,7 +15,7 @@
   <nb-card-body>
     <form [formGroup]="form">
       <!--      GROUP-->
-      <div [hidden]="!!group || isEdit">
+      <div [hidden]="!!group">
         <nb-form-field>
           <div>
             <label class="font-weight-bold">Agent Group</label>


### PR DESCRIPTION
rollback dataset-from rule for showing agent_group_id selector dropdown.
![image](https://user-images.githubusercontent.com/1490938/169902780-f1041369-d625-4665-be47-458ac45a3873.png)