### PR TITLE
fix(orb-ui): add tooltips to agent and orb tags display

### DIFF
--- a/ui/src/app/shared/components/orb/combined-tag/combined-tag.component.html
+++ b/ui/src/app/shared/components/orb/combined-tag/combined-tag.component.html
@@ -1,18 +1,10 @@
 <div>
   <br>
-  <button
-    (click)="splitView=!splitView"
-    class="card-ghost-button"
-    ghost="true"
-    nbButton
-    status="primary">{{ splitView ? 'Unify' : 'Split' }}</button>
-  <div [hidden]="splitView">
-    <p class="detail-title">Combined Tags</p>
-    <ngx-tag-display [tags]="agent.combined_tags"></ngx-tag-display>
-  </div>
-  <div [hidden]="!splitView">
+  <div matTooltip="These tags were configured in the agent and were inherited into Orb">
     <p class="detail-title">Agent Tags</p>
     <ngx-tag-display [tags]="agent.agent_tags"></ngx-tag-display>
+  </div>
+  <div matTooltip="These tags were configured in Orb and propagated to the agent">
     <br>
     <p class="detail-title">Orb Tags</p>
     <ngx-tag-display [tags]="agent.orb_tags"></ngx-tag-display>

--- a/ui/src/app/shared/components/orb/combined-tag/combined-tag.component.ts
+++ b/ui/src/app/shared/components/orb/combined-tag/combined-tag.component.ts
@@ -10,8 +10,6 @@ export class CombinedTagComponent implements OnInit {
   @Input()
   agent: Agent;
 
-  splitView = false;
-
   constructor() { }
 
   ngOnInit(): void {


### PR DESCRIPTION
https://github.com/ns1labs/orb/issues/1242#issuecomment-1140059666

add tooltip to agent and orb tags, remove unified|split thing button