### PR TITLE
fix(agent): add reset comms method and extract call

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -155,11 +155,6 @@ func (a *orbAgent) RestartBackend(name string, reason string) error {
 		return errors.New("specified backend does not exist: " + name)
 	}
 
-	err := a.restartComms()
-	if err != nil {
-		return err
-	}
-
 	be := a.backends[name]
 	a.logger.Info("restarting backend", zap.String("backend", name), zap.String("reason", reason))
 	a.logger.Info("removing policies", zap.String("backend", name))
@@ -202,6 +197,7 @@ func (a *orbAgent) RestartAll(reason string) error {
 
 	a.logger.Info("restarting all backends", zap.String("reason", reason))
 	for name := range a.backends {
+		a.logger.Info("restarting backend", zap.String("backend", name), zap.String("reason", reason))
 		err = a.RestartBackend(name, reason)
 		if err != nil {
 			a.logger.Error("failed to restart backend", zap.Error(err))

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -185,6 +185,8 @@ func (a *orbAgent) restartComms() error {
 	if err := a.startComms(cloudConfig); err != nil {
 		return err
 	}
+
+	a.requestReconnection(a.client, cloudConfig)
 	return nil
 }
 

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -321,7 +321,7 @@ func (p *pktvisorBackend) scrapeDefault() error {
 		for pName, pMetrics := range metrics {
 			data, err := p.policyRepo.GetByName(pName)
 			if err != nil {
-				p.logger.Error("skipping pktvisor policy not managed by orb", zap.String("policy", pName), zap.Error(err))
+				p.logger.Warn("skipping pktvisor policy not managed by orb", zap.String("policy", pName), zap.Error(err))
 				continue
 			}
 			payloadData, err := json.Marshal(pMetrics)

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -81,7 +81,7 @@ func (a *orbAgent) removeDatasetFromPolicy(datasetID string, policyID string) {
 func (a *orbAgent) startComms(config config.MQTTConfig) error {
 
 	var err error
-	if !a.client.IsConnected() {
+	if a.client == nil || !a.client.IsConnected() {
 		a.client, err = a.connect(config)
 		if err != nil {
 			a.logger.Error("connection failed", zap.String("channel", config.ChannelID), zap.String("agent_id", config.Id), zap.Error(err))
@@ -115,10 +115,6 @@ func (a *orbAgent) startComms(config config.MQTTConfig) error {
 	if err != nil {
 		a.logger.Error("failed to send agent policies request", zap.Error(err))
 	}
-
-	a.hbTicker = time.NewTicker(HeartbeatFreq)
-	a.hbDone = make(chan bool)
-	go a.sendHeartbeats()
 
 	return nil
 }

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -81,10 +81,12 @@ func (a *orbAgent) removeDatasetFromPolicy(datasetID string, policyID string) {
 func (a *orbAgent) startComms(config config.MQTTConfig) error {
 
 	var err error
-	a.client, err = a.connect(config)
-	if err != nil {
-		a.logger.Error("connection failed", zap.String("channel", config.ChannelID), zap.String("agent_id", config.Id), zap.Error(err))
-		return ErrMqttConnection
+	if !a.client.IsConnected() {
+		a.client, err = a.connect(config)
+		if err != nil {
+			a.logger.Error("connection failed", zap.String("channel", config.ChannelID), zap.String("agent_id", config.Id), zap.Error(err))
+			return ErrMqttConnection
+		}
 	}
 
 	a.nameAgentRPCTopics(config.ChannelID)

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -25,6 +25,11 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 	})
 	opts.SetPingTimeout(5 * time.Second)
 	opts.SetAutoReconnect(true)
+	opts.SetConnectRetry(true)
+	opts.SetConnectRetryInterval(5 * time.Second)
+	opts.SetOnConnectHandler(func(client mqtt.Client) {
+		a.requestReconnection(client, config)
+	})
 
 	if !a.config.OrbAgent.TLS.Verify {
 		opts.TLSConfig = &tls.Config{InsecureSkipVerify: true}
@@ -36,6 +41,27 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 	}
 
 	return c, nil
+}
+
+func (a *orbAgent) requestReconnection(client mqtt.Client, config config.MQTTConfig) {
+	a.nameAgentRPCTopics(config.ChannelID)
+	for name, be := range a.backends {
+		be.SetCommsClient(config.Id, client, fmt.Sprintf("%s/be/%s", a.baseTopic, name))
+	}
+
+	if token := client.Subscribe(a.rpcFromCoreTopic, 1, a.handleRPCFromCore); token.Wait() && token.Error() != nil {
+		a.logger.Error("failed to subscribe to RPC topic", zap.String("topic", a.rpcFromCoreTopic), zap.Error(token.Error()))
+	}
+
+	err := a.sendCapabilities()
+	if err != nil {
+		a.logger.Error("failed to send agent capabilities", zap.Error(err))
+	}
+
+	err = a.sendGroupMembershipReq()
+	if err != nil {
+		a.logger.Error("failed to send group membership request", zap.Error(err))
+	}
 }
 
 func (a *orbAgent) nameAgentRPCTopics(channelId string) {
@@ -87,33 +113,6 @@ func (a *orbAgent) startComms(config config.MQTTConfig) error {
 			a.logger.Error("connection failed", zap.String("channel", config.ChannelID), zap.String("agent_id", config.Id), zap.Error(err))
 			return ErrMqttConnection
 		}
-	}
-
-	a.nameAgentRPCTopics(config.ChannelID)
-
-	for name, be := range a.backends {
-		be.SetCommsClient(config.Id, a.client, fmt.Sprintf("%s/be/%s", a.baseTopic, name))
-	}
-
-	if token := a.client.Subscribe(a.rpcFromCoreTopic, 1, a.handleRPCFromCore); token.Wait() && token.Error() != nil {
-		a.logger.Error("failed to subscribe to RPC topic", zap.String("topic", a.rpcFromCoreTopic), zap.Error(token.Error()))
-		return token.Error()
-	}
-
-	err = a.sendCapabilities()
-	if err != nil {
-		a.logger.Error("failed to send agent capabilities", zap.Error(err))
-		return err
-	}
-
-	err = a.sendGroupMembershipReq()
-	if err != nil {
-		a.logger.Error("failed to send group membership request", zap.Error(err))
-	}
-
-	err = a.sendAgentPoliciesReq()
-	if err != nil {
-		a.logger.Error("failed to send agent policies request", zap.Error(err))
 	}
 
 	return nil

--- a/agent/rpc_from.go
+++ b/agent/rpc_from.go
@@ -141,8 +141,12 @@ func (a *orbAgent) handleAgentReset(payload fleet.AgentResetRPCPayload) {
 			a.logger.Error("RestartAll failure", zap.Error(err))
 		}
 	} else {
-		// TODO backend specific restart
-		// a.RestartBackend()
+		for name, _ := range a.backends {
+			err := a.RestartBackend(name, payload.Reason)
+			if err != nil {
+				a.logger.Error("RestartBackend failure", zap.Error(err))
+			}
+		}
 	}
 }
 

--- a/agent/rpc_from.go
+++ b/agent/rpc_from.go
@@ -141,12 +141,8 @@ func (a *orbAgent) handleAgentReset(payload fleet.AgentResetRPCPayload) {
 			a.logger.Error("RestartAll failure", zap.Error(err))
 		}
 	} else {
-		for name, _ := range a.backends {
-			err := a.RestartBackend(name, payload.Reason)
-			if err != nil {
-				a.logger.Error("RestartBackend failure", zap.Error(err))
-			}
-		}
+		// TODO backend specific restart
+		// a.RestartBackend()
 	}
 }
 


### PR DESCRIPTION
This fixes #1120 

![image](https://user-images.githubusercontent.com/6593889/172265768-4ccceab3-4b2a-4865-a915-8766b11b09dd.png)

This adds the restart comms in the agent reset, and it managed to remotely fix any connection issues of desynchronization of subscription / unsubscription with the agent.



logs
```
{"level":"info","caller":"agent/agent.go:198","msg":"restarting all backends","reason":"Reset initiated from control plane"}{"level":"info","caller":"agent/agent.go:200","msg":"restarting backend","backend":"pktvisor","reason":"Reset initiated from control plane"}
{"level":"info","caller":"agent/agent.go:159","msg":"restarting backend","backend":"pktvisor","reason":"Reset initiated from control plane"}
{"level":"info","caller":"agent/agent.go:160","msg":"removing policies","backend":"pktvisor"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:36.126] [visor] [info] policy [newpolicy]: stopping"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:36.126] [visor] [info] policy [newpolicy]: input instance default_pcap-553e93901e462a6e not stopped because it is in use by another policy."}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:36.126] [visor] [info] policy [newpolicy]: stopping handler instance: newpolicy-handler_dhcp_1"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:36.126] [visor] [info] policy [newpolicy]: stopping handler instance: newpolicy-handler_dns_1"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:36.126] [visor] [info] policy [default_pcap-553e93901e462a6e-resources]: stopping"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:36.126] [visor] [info] policy [default_pcap-553e93901e462a6e-resources]: stopping input instance: default_pcap-553e93901e462a6e"}
{"level":"info","caller":"agent/agent.go:164","msg":"resetting backend","backend":"pktvisor"}
{"level":"info","caller":"pktvisor/pktvisor.go:398","msg":"pktvisor stopping"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:38.040] [visor] [info] REQUEST: DELETE /api/v1/policies/newpolicy 200"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:38.040] [visor] [info] Shutting down"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.042] [visor] [info] exit with success"}
{"level":"info","caller":"pktvisor/pktvisor.go:411","msg":"pktvisor process stopped","pid":36,"exit_code":0}
{"level":"info","caller":"pktvisor/pktvisor.go:240","msg":"pktvisor startup","arguments":["--admin-api","-l","localhost","-p","10853","--config","/tmp/orb-agent-pktvisor-conf.kSCg19"]}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.083] [visor] [info] pktvisor 4.2.0-develop-0beb837 starting up"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Load input stream plugin: dnstap visor.module.input/1.0"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Load input stream plugin: mock visor.module.input/1.0"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Load input stream plugin: pcap visor.module.input/1.0"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Load input stream plugin: sflow visor.module.input/1.0"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Load stream handler plugin: dhcp visor.module.handler/1.0"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Load stream handler plugin: dns visor.module.handler/1.0"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Load stream handler plugin: input_resources visor.module.handler/1.0"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Load stream handler plugin: net visor.module.handler/1.0"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Load stream handler plugin: pcap visor.module.handler/1.0"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Initialize server control plane"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Registering DELETE /api/v1/server"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Registering GET /api/v1/metrics/app"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Registering GET /api/v1/metrics/rates"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Registering GET /api/v1/metrics/bucket/(\\d+)"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Registering GET /api/v1/metrics/window/(\\d+)"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] enabling prometheus metrics for \"default\" policy on: /metrics"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Registering GET /metrics"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Registering GET /api/v1/taps"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Registering GET /api/v1/policies"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Registering POST /api/v1/policies"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.084] [visor] [info] Registering GET /api/v1/policies/([a-zA-Z_][a-zA-Z0-9_-]*)"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.085] [visor] [info] Registering DELETE /api/v1/policies/([a-zA-Z_][a-zA-Z0-9_-]*)"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.085] [visor] [info] Registering GET /api/v1/policies/([a-zA-Z_][a-zA-Z0-9_-]*)/metrics/(window|bucket)/(\\d+)"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.086] [visor] [info] Registering GET /api/v1/policies/([a-zA-Z_][a-zA-Z0-9_-]*)/metrics/prometheus"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.086] [visor] [info] tap [default_pcap]: parsing"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.087] [visor] [info] tap [default_pcap]: loaded, type pcap"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.087] [visor] [info] sending anonymous usage metrics (once/day, use --no-track to disable): 738beb0-poleved-0.2.4.pktvisord.metrics.pktvisor.dev."}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:43.244] [visor] [info] web server listening on localhost:10853"}
{"level":"info","caller":"pktvisor/pktvisor.go:287","msg":"pktvisor process started","pid":52}
{"level":"info","caller":"agent/agent.go:168","msg":"reapplying policies","backend":"pktvisor"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.046] [visor] [info] policy [newpolicy]: parsing"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.047] [visor] [info] policy [newpolicy]: instantiating Tap: default_pcap"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.048] [visor] [info] policy [newpolicy]: instantiating Handler handler_dhcp_1 of type dhcp"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.050] [visor] [info] policy [newpolicy]: instantiating Handler handler_dns_1 of type dns"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.061] [visor] [info] policy [newpolicy]: starting"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.061] [visor] [info] policy [newpolicy]: starting handler instance: newpolicy-handler_dhcp_1"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.061] [visor] [info] policy [newpolicy]: starting handler instance: newpolicy-handler_dns_1"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.061] [visor] [info] policy [newpolicy]: starting input instance: default_pcap-553e93901e462a6e"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.083] [visor] [info] policy [default_pcap-553e93901e462a6e-resources]: starting"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.083] [visor] [info] policy [default_pcap-553e93901e462a6e-resources]: starting handler instance: default_pcap-553e93901e462a6e-resources"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.083] [visor] [info] policy [default_pcap-553e93901e462a6e-resources]: starting input instance: default_pcap-553e93901e462a6e"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.084] [visor] [info] REQUEST: POST /api/v1/policies 200"}
{"level":"info","caller":"policyMgr/manager.go:226","msg":"policy applied successfully","policy_id":"2e9b1fb7-de45-4ef5-abfb-880817f0f64a","policy_name":"newpolicy"}
{"level":"info","caller":"agent/agent.go:206","msg":"all backends and comms were restarted"}
{"level":"info","caller":"agent/comms.go:60","msg":"completed RPC unsubscription to group","group_id":"3d20fc26-e795-4869-9353-f44f1fef8e95","group_name":"grp2","topic":"channels/30c2a0a3-515b-4683-8cd8-b25f6e0bb7bf/messages/fromcore"}
{"level":"info","caller":"agent/comms.go:60","msg":"completed RPC unsubscription to group","group_id":"d28df36b-1b80-40eb-a833-ddcbbbb87b96","group_name":"gr1","topic":"channels/dcf323c3-5c67-40fd-8461-aff473c6966e/messages/fromcore"}
{"level":"info","caller":"agent/comms.go:142","msg":"completed RPC subscription to group","group_id":"d28df36b-1b80-40eb-a833-ddcbbbb87b96","group_name":"gr1","topic":"channels/dcf323c3-5c67-40fd-8461-aff473c6966e/messages/fromcore"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.930] [visor] [info] policy [newpolicy]: stopping"}
:"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.930] [visor] [info] policy [newpolicy]: input instance default_pcap-553e93901e462a6e not stopped because it is in use by another policy."}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.930] [visor] [info] policy [newpolicy]: stopping handler instance: newpolicy-handler_dhcp_1"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.930] [visor] [info] policy [newpolicy]: stopping handler instance: newpolicy-handler_dns_1"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.930] [visor] [info] policy [default_pcap-553e93901e462a6e-resources]: stopping"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:44.931] [visor] [info] policy [default_pcap-553e93901e462a6e-resources]: stopping input instance: default_pcap-553e93901e462a6e"}
:"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:46.199] [visor] [info] policy [default_pcap-553e93901e462a6e-resources]: stopping handler instance: default_pcap-553e93901e462a6e-resources"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:25:46.199] [visor] [info] REQUEST: DELETE /api/v1/policies/newpolicy 200"}
{"level":"warn","caller":"pktvisor/pktvisor.go:315","msg":"scrape: no policies found, skipping"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:26:44.046] [visor] [info] REQUEST: GET /api/v1/policies/__all/metrics/bucket/1 200"}
{"level":"info","caller":"policyMgr/manager.go:55","msg":"managing agent policy from core","action":"manage","name":"newpolicy","dataset":"98802e1e-7799-4839-b02b-48944836fea3","backend":"pktvisor","id":"2e9b1fb7-de45-4ef5-abfb-880817f0f64a","version":0}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:22.894] [visor] [info] policy [newpolicy]: parsing"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:22.894] [visor] [info] policy [newpolicy]: instantiating Tap: default_pcap"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:22.896] [visor] [info] policy [newpolicy]: instantiating Handler handler_dhcp_1 of type dhcp"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:22.899] [visor] [info] policy [newpolicy]: instantiating Handler handler_dns_1 of type dns"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:22.907] [visor] [info] policy [newpolicy]: starting"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:22.907] [visor] [info] policy [newpolicy]: starting handler instance: newpolicy-handler_dhcp_1"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:22.907] [visor] [info] policy [newpolicy]: starting handler instance: newpolicy-handler_dns_1"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:22.908] [visor] [info] policy [newpolicy]: starting input instance: default_pcap-553e93901e462a6e"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:22.944] [visor] [info] policy [default_pcap-553e93901e462a6e-resources]: starting"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:22.944] [visor] [info] policy [default_pcap-553e93901e462a6e-resources]: starting handler instance: default_pcap-553e93901e462a6e-resources"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:22.945] [visor] [info] policy [default_pcap-553e93901e462a6e-resources]: starting input instance: default_pcap-553e93901e462a6e"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:22.945] [visor] [info] REQUEST: POST /api/v1/policies 200"}
{"level":"info","caller":"policyMgr/manager.go:183","msg":"policy applied successfully","policy_id":"2e9b1fb7-de45-4ef5-abfb-880817f0f64a","policy_name":"newpolicy"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:44.047] [visor] [warning] default_pcap-553e93901e462a6e-resources handler for policy default_pcap-553e93901e462a6e-resources had a PeriodException, skipping: requested metrics period has not yet accumulated, current range is [0, 0]"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:44.047] [visor] [warning] newpolicy-handler_dhcp_1 handler for policy newpolicy had a PeriodException, skipping: requested metrics period has not yet accumulated, current range is [0, 0]"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:44.047] [visor] [warning] newpolicy-handler_dns_1 handler for policy newpolicy had a PeriodException, skipping: requested metrics period has not yet accumulated, current range is [0, 0]"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:27:44.047] [visor] [info] REQUEST: GET /api/v1/policies/__all/metrics/bucket/1 200"}
{"level":"warn","caller":"pktvisor/pktvisor.go:315","msg":"scrape: no policies found, skipping"}
{"level":"info","caller":"policyMgr/manager.go:55","msg":"managing agent policy from core","action":"manage","name":"otherpolicy","dataset":"07180cb8-7560-484d-9efc-bbc119c22eb1","backend":"pktvisor","id":"310b8758-9dfe-4397-9255-d053661d5da8","version":0}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:28:11.278] [visor] [info] policy [otherpolicy]: parsing"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:28:11.278] [visor] [info] policy [otherpolicy]: input stream already exists. reusing: default_pcap-553e93901e462a6e"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:28:11.279] [visor] [info] policy [otherpolicy]: instantiating Handler handler_net_1 of type net"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:28:11.283] [visor] [info] policy [otherpolicy]: starting"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:28:11.283] [visor] [info] policy [otherpolicy]: starting handler instance: otherpolicy-handler_net_1"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:28:11.283] [visor] [info] policy [otherpolicy]: starting input instance: default_pcap-553e93901e462a6e"}
{"level":"info","caller":"policyMgr/manager.go:183","msg":"policy applied successfully","policy_id":"310b8758-9dfe-4397-9255-d053661d5da8","policy_name":"otherpolicy"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:28:11.284] [visor] [info] REQUEST: POST /api/v1/policies 200"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:28:44.047] [visor] [warning] otherpolicy-handler_net_1 handler for policy otherpolicy had a PeriodException, skipping: requested metrics period has not yet accumulated, current range is [0, 0]"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:28:44.047] [visor] [warning] newpolicy-handler_dhcp_1 handler for policy newpolicy had a PeriodException, skipping: requested metrics period has not yet accumulated, current range is [0, 0]"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:28:44.047] [visor] [info] REQUEST: GET /api/v1/policies/__all/metrics/bucket/1 200"}
{"level":"warn","caller":"pktvisor/pktvisor.go:324","msg":"skipping pktvisor policy not managed by orb","policy":"default_pcap-553e93901e462a6e-resources","error":"policy name not found"}
{"level":"info","caller":"pktvisor/pktvisor.go:342","msg":"scraped metrics for policy","policy":"newpolicy","policy_id":"2e9b1fb7-de45-4ef5-abfb-880817f0f64a","payload_size_b":1371}
{"level":"info","caller":"pktvisor/pktvisor.go:360","msg":"scraped and published metrics","topic":"channels/d10d02b9-53f0-47c1-af56-abf3518b4604/messages/be/pktvisor/m/d","payload_size_b":1371,"batch_count":1}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:29:44.047] [visor] [warning] newpolicy-handler_dhcp_1 handler for policy newpolicy had a PeriodException, skipping: requested metrics period has not yet accumulated, current range is [0, 0]"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:29:44.048] [visor] [info] REQUEST: GET /api/v1/policies/__all/metrics/bucket/1 200"}
{"level":"warn","caller":"pktvisor/pktvisor.go:324","msg":"skipping pktvisor policy not managed by orb","policy":"default_pcap-553e93901e462a6e-resources","error":"policy name not found"}
{"level":"info","caller":"pktvisor/pktvisor.go:342","msg":"scraped metrics for policy","policy":"newpolicy","policy_id":"2e9b1fb7-de45-4ef5-abfb-880817f0f64a","payload_size_b":1929}
{"level":"info","caller":"pktvisor/pktvisor.go:342","msg":"scraped metrics for policy","policy":"otherpolicy","policy_id":"310b8758-9dfe-4397-9255-d053661d5da8","payload_size_b":1143}
{"level":"info","caller":"pktvisor/pktvisor.go:360","msg":"scraped and published metrics","topic":"channels/d10d02b9-53f0-47c1-af56-abf3518b4604/messages/be/pktvisor/m/d","payload_size_b":3072,"batch_count":2}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:30:44.048] [visor] [warning] newpolicy-handler_dhcp_1 handler for policy newpolicy had a PeriodException, skipping: requested metrics period has not yet accumulated, current range is [0, 0]"}
{"level":"info","caller":"pktvisor/pktvisor.go:258","msg":"pktvisor stdout","log":"[2022-06-06 23:30:44.048] [visor] [info] REQUEST: GET /api/v1/policies/__all/metrics/bucket/1 200"}
{"level":"warn","caller":"pktvisor/pktvisor.go:324","msg":"skipping pktvisor policy not managed by orb","policy":"default_pcap-553e93901e462a6e-resources","error":"policy name not found"}
{"level":"info","caller":"pktvisor/pktvisor.go:342","msg":"scraped metrics for policy","policy":"newpolicy","policy_id":"2e9b1fb7-de45-4ef5-abfb-880817f0f64a","payload_size_b":1635}
{"level":"info","caller":"pktvisor/pktvisor.go:342","msg":"scraped metrics for policy","policy":"otherpolicy","policy_id":"310b8758-9dfe-4397-9255-d053661d5da8","payload_size_b":1150}
{"level":"info","caller":"pktvisor/pktvisor.go:360","msg":"scraped and published metrics","topic":"channels/d10d02b9-53f0-47c1-af56-abf3518b4604/messages/be/pktvisor/m/d","payload_size_b":2785,"batch_count":2}
```