### PR TITLE
Feature/orb 1300 add policy status agent list

### DIFF
--- a/fleet/agent_service.go
+++ b/fleet/agent_service.go
@@ -275,15 +275,17 @@ func (svc fleetService) ViewAgentInfoByChannelIDInternal(ctx context.Context, ch
 	return res, nil
 }
 
-func (svc fleetService) GetPoliciesState(ctx context.Context, agent Agent) (map[string]interface{}, error) {
+func (svc fleetService) GetPolicyState(ctx context.Context, agent Agent) (map[string]interface{}, error) {
 
 	jsonHb, err := json.Marshal(agent.LastHBData)
 	if err != nil {
 		svc.logger.Error("failed to marshal heartbeat data", zap.Error(err))
+		return nil, err
 	}
 	var hb Heartbeat
 	if err = json.Unmarshal(jsonHb, &hb); err != nil {
 		svc.logger.Error("failed to unmarshal heartbeat data", zap.Error(err))
+		return nil, err
 	}
 
 	policyState := make(map[string]interface{})

--- a/fleet/agent_service.go
+++ b/fleet/agent_service.go
@@ -10,6 +10,7 @@ package fleet
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/mainflux/mainflux"
 	mfsdk "github.com/mainflux/mainflux/pkg/sdk/go"
 	"github.com/ns1labs/orb/fleet/backend"
@@ -272,4 +273,26 @@ func (svc fleetService) ViewAgentInfoByChannelIDInternal(ctx context.Context, ch
 		return Agent{}, err
 	}
 	return res, nil
+}
+
+func (svc fleetService) GetPoliciesState(agent Agent, ctx context.Context) (map[string]interface{}, error) {
+
+	jsonHb, err := json.Marshal(agent.LastHBData)
+	if err != nil {
+		svc.logger.Error("failed to marshal heartbeat data", zap.Error(err))
+	}
+	var hb Heartbeat
+	if err = json.Unmarshal(jsonHb, &hb); err != nil {
+		svc.logger.Error("failed to unmarshal heartbeat data", zap.Error(err))
+	}
+
+	policyState := make(map[string]interface{})
+	for policyID, policyInfo := range hb.PolicyState {
+		formattedPolicyInfo := policyInfo
+		formattedPolicyInfo.Datasets = []string{}
+
+		policyState[policyID] = formattedPolicyInfo
+	}
+
+	return policyState, nil
 }

--- a/fleet/agent_service.go
+++ b/fleet/agent_service.go
@@ -275,7 +275,7 @@ func (svc fleetService) ViewAgentInfoByChannelIDInternal(ctx context.Context, ch
 	return res, nil
 }
 
-func (svc fleetService) GetPoliciesState(agent Agent, ctx context.Context) (map[string]interface{}, error) {
+func (svc fleetService) GetPoliciesState(ctx context.Context, agent Agent) (map[string]interface{}, error) {
 
 	jsonHb, err := json.Marshal(agent.LastHBData)
 	if err != nil {

--- a/fleet/agent_service_test.go
+++ b/fleet/agent_service_test.go
@@ -524,41 +524,6 @@ func TestViewAgentInfoByChannelIDInternal(t *testing.T) {
 	}
 }
 
-func TestGetPoliciesState(t *testing.T) {
-	users := flmocks.NewAuthService(map[string]string{token: email})
-
-	thingsServer := newThingsServer(newThingsService(users))
-	fleetService := newService(users, thingsServer.URL)
-
-	ag, err := createAgent(t, "my-agent", fleetService)
-	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
-
-	cases := map[string]struct {
-		policiesState map[string]interface{}
-		agent         fleet.Agent
-		err           error
-	}{
-		"get policies state info by existent agent": {
-			policiesState: ag.MFChannelID,
-			agent:         ag,
-			err:           nil,
-		},
-		//"view agent info by non-existent channelID": {
-		//	channelID: chID.String(),
-		//	agent:     fleet.Agent{},
-		//	err:       errors.ErrNotFound,
-		//},
-	}
-
-	for desc, tc := range cases {
-		t.Run(desc, func(t *testing.T) {
-			agent, err := fleetService.GetPoliciesState(context.Background(), tc.agent)
-			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s", desc, tc.err, err))
-			assert.Equal(t, tc.agent, agent, fmt.Sprintf("%s: expected %s got %s", desc, tc.agent, agent))
-		})
-	}
-}
-
 func createAgent(t *testing.T, name string, svc fleet.Service) (fleet.Agent, error) {
 	t.Helper()
 	aCopy := agent

--- a/fleet/agent_service_test.go
+++ b/fleet/agent_service_test.go
@@ -524,6 +524,41 @@ func TestViewAgentInfoByChannelIDInternal(t *testing.T) {
 	}
 }
 
+func TestGetPoliciesState(t *testing.T) {
+	users := flmocks.NewAuthService(map[string]string{token: email})
+
+	thingsServer := newThingsServer(newThingsService(users))
+	fleetService := newService(users, thingsServer.URL)
+
+	ag, err := createAgent(t, "my-agent", fleetService)
+	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
+
+	cases := map[string]struct {
+		policiesState map[string]interface{}
+		agent         fleet.Agent
+		err           error
+	}{
+		"get policies state info by existent agent": {
+			policiesState: ag.MFChannelID,
+			agent:         ag,
+			err:           nil,
+		},
+		//"view agent info by non-existent channelID": {
+		//	channelID: chID.String(),
+		//	agent:     fleet.Agent{},
+		//	err:       errors.ErrNotFound,
+		//},
+	}
+
+	for desc, tc := range cases {
+		t.Run(desc, func(t *testing.T) {
+			agent, err := fleetService.GetPoliciesState(context.Background(), tc.agent)
+			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s", desc, tc.err, err))
+			assert.Equal(t, tc.agent, agent, fmt.Sprintf("%s: expected %s got %s", desc, tc.agent, agent))
+		})
+	}
+}
+
 func createAgent(t *testing.T, name string, svc fleet.Service) (fleet.Agent, error) {
 	t.Helper()
 	aCopy := agent

--- a/fleet/agents.go
+++ b/fleet/agents.go
@@ -107,8 +107,8 @@ type AgentService interface {
 	ViewAgentInfoByChannelIDInternal(ctx context.Context, channelID string) (Agent, error)
 	// ResetAgent reset a agent on edge by a provided agent
 	ResetAgent(ct context.Context, token string, agentID string) error
-	// GetPoliciesState get all policies state per agent in a formatted way
-	GetPoliciesState(ctx context.Context, agent Agent) (map[string]interface{}, error)
+	// GetPolicyState get all policies state per agent in a formatted way from a given existent agent
+	GetPolicyState(ctx context.Context, agent Agent) (map[string]interface{}, error)
 }
 
 type AgentRepository interface {

--- a/fleet/agents.go
+++ b/fleet/agents.go
@@ -107,6 +107,8 @@ type AgentService interface {
 	ViewAgentInfoByChannelIDInternal(ctx context.Context, channelID string) (Agent, error)
 	// ResetAgent reset a agent on edge by a provided agent
 	ResetAgent(ct context.Context, token string, agentID string) error
+	// GetPoliciesState get all policies state per agent in a formatted way
+	GetPoliciesState(ctx context.Context, agent Agent) (map[string]interface{}, error)
 }
 
 type AgentRepository interface {

--- a/fleet/api/http/endpoint.go
+++ b/fleet/api/http/endpoint.go
@@ -293,7 +293,7 @@ func listAgentsEndpoint(svc fleet.Service) endpoint.Endpoint {
 
 		for _, ag := range page.Agents {
 
-			policyState, err := svc.GetPoliciesState(ag, nil)
+			policyState, err := svc.GetPoliciesState(ctx, ag)
 			if err != nil {
 				return nil, err
 			}

--- a/fleet/api/http/endpoint.go
+++ b/fleet/api/http/endpoint.go
@@ -292,8 +292,8 @@ func listAgentsEndpoint(svc fleet.Service) endpoint.Endpoint {
 			Agents: []agentRes{},
 		}
 
-		policyStatus := make(map[string]interface{})
 		for _, ag := range page.Agents {
+			policyStatus := make(map[string]interface{})
 			var hb fleet.Heartbeat
 			err = mapstructure.Decode(ag.LastHBData, &hb)
 			if err != nil {

--- a/fleet/api/http/endpoint.go
+++ b/fleet/api/http/endpoint.go
@@ -293,21 +293,21 @@ func listAgentsEndpoint(svc fleet.Service) endpoint.Endpoint {
 
 		for _, ag := range page.Agents {
 
-			policyState, err := svc.GetPoliciesState(ctx, ag)
+			policiesState, err := svc.GetPoliciesState(ctx, ag)
 			if err != nil {
 				return nil, err
 			}
 
 			view := agentRes{
-				ID:          ag.MFThingID,
-				Name:        ag.Name.String(),
-				ChannelID:   ag.MFChannelID,
-				AgentTags:   ag.AgentTags,
-				OrbTags:     ag.OrbTags,
-				TsCreated:   ag.Created,
-				State:       ag.State.String(),
-				TsLastHB:    ag.LastHB,
-				PolicyState: policyState,
+				ID:            ag.MFThingID,
+				Name:          ag.Name.String(),
+				ChannelID:     ag.MFChannelID,
+				AgentTags:     ag.AgentTags,
+				OrbTags:       ag.OrbTags,
+				TsCreated:     ag.Created,
+				State:         ag.State.String(),
+				TsLastHB:      ag.LastHB,
+				PoliciesState: policiesState,
 			}
 			res.Agents = append(res.Agents, view)
 		}

--- a/fleet/api/http/endpoint.go
+++ b/fleet/api/http/endpoint.go
@@ -293,21 +293,18 @@ func listAgentsEndpoint(svc fleet.Service) endpoint.Endpoint {
 
 		for _, ag := range page.Agents {
 
-			policiesState, err := svc.GetPoliciesState(ctx, ag)
-			if err != nil {
-				return nil, err
-			}
+			policyState, _ := svc.GetPolicyState(ctx, ag)
 
 			view := agentRes{
-				ID:            ag.MFThingID,
-				Name:          ag.Name.String(),
-				ChannelID:     ag.MFChannelID,
-				AgentTags:     ag.AgentTags,
-				OrbTags:       ag.OrbTags,
-				TsCreated:     ag.Created,
-				State:         ag.State.String(),
-				TsLastHB:      ag.LastHB,
-				PoliciesState: policiesState,
+				ID:          ag.MFThingID,
+				Name:        ag.Name.String(),
+				ChannelID:   ag.MFChannelID,
+				AgentTags:   ag.AgentTags,
+				OrbTags:     ag.OrbTags,
+				TsCreated:   ag.Created,
+				State:       ag.State.String(),
+				TsLastHB:    ag.LastHB,
+				PolicyState: policyState,
 			}
 			res.Agents = append(res.Agents, view)
 		}

--- a/fleet/api/http/logging.go
+++ b/fleet/api/http/logging.go
@@ -293,19 +293,19 @@ func (l loggingMiddleware) RemoveAgent(ctx context.Context, token, thingID strin
 	return l.svc.RemoveAgent(ctx, token, thingID)
 }
 
-func (l loggingMiddleware) GetPoliciesState(ctx context.Context, agent fleet.Agent) (_ map[string]interface{}, err error) {
+func (l loggingMiddleware) GetPolicyState(ctx context.Context, agent fleet.Agent) (_ map[string]interface{}, err error) {
 	defer func(begin time.Time) {
 		if err != nil {
-			l.logger.Warn("method call: get_policies_state",
+			l.logger.Warn("method call: get_policy_state",
 				zap.Error(err),
 				zap.Duration("duration", time.Since(begin)))
 		} else {
-			l.logger.Info("method call: get_policies_state",
+			l.logger.Info("method call: get_policy_state",
 				zap.Duration("duration", time.Since(begin)))
 		}
 	}(time.Now())
 
-	return l.svc.GetPoliciesState(ctx, agent)
+	return l.svc.GetPolicyState(ctx, agent)
 }
 
 func NewLoggingMiddleware(svc fleet.Service, logger *zap.Logger) fleet.Service {

--- a/fleet/api/http/logging.go
+++ b/fleet/api/http/logging.go
@@ -293,6 +293,21 @@ func (l loggingMiddleware) RemoveAgent(ctx context.Context, token, thingID strin
 	return l.svc.RemoveAgent(ctx, token, thingID)
 }
 
+func (l loggingMiddleware) GetPoliciesState(agent fleet.Agent, ctx context.Context) (_ map[string]interface{}, err error) {
+	defer func(begin time.Time) {
+		if err != nil {
+			l.logger.Warn("method call: get_policy_state",
+				zap.Error(err),
+				zap.Duration("duration", time.Since(begin)))
+		} else {
+			l.logger.Info("method call: get_policy_state",
+				zap.Duration("duration", time.Since(begin)))
+		}
+	}(time.Now())
+
+	return l.svc.GetPoliciesState(agent, nil)
+}
+
 func NewLoggingMiddleware(svc fleet.Service, logger *zap.Logger) fleet.Service {
 	return &loggingMiddleware{logger, svc}
 }

--- a/fleet/api/http/logging.go
+++ b/fleet/api/http/logging.go
@@ -296,11 +296,11 @@ func (l loggingMiddleware) RemoveAgent(ctx context.Context, token, thingID strin
 func (l loggingMiddleware) GetPoliciesState(ctx context.Context, agent fleet.Agent) (_ map[string]interface{}, err error) {
 	defer func(begin time.Time) {
 		if err != nil {
-			l.logger.Warn("method call: get_policy_state",
+			l.logger.Warn("method call: get_policies_state",
 				zap.Error(err),
 				zap.Duration("duration", time.Since(begin)))
 		} else {
-			l.logger.Info("method call: get_policy_state",
+			l.logger.Info("method call: get_policies_state",
 				zap.Duration("duration", time.Since(begin)))
 		}
 	}(time.Now())

--- a/fleet/api/http/logging.go
+++ b/fleet/api/http/logging.go
@@ -293,7 +293,7 @@ func (l loggingMiddleware) RemoveAgent(ctx context.Context, token, thingID strin
 	return l.svc.RemoveAgent(ctx, token, thingID)
 }
 
-func (l loggingMiddleware) GetPoliciesState(agent fleet.Agent, ctx context.Context) (_ map[string]interface{}, err error) {
+func (l loggingMiddleware) GetPoliciesState(ctx context.Context, agent fleet.Agent) (_ map[string]interface{}, err error) {
 	defer func(begin time.Time) {
 		if err != nil {
 			l.logger.Warn("method call: get_policy_state",
@@ -305,7 +305,7 @@ func (l loggingMiddleware) GetPoliciesState(agent fleet.Agent, ctx context.Conte
 		}
 	}(time.Now())
 
-	return l.svc.GetPoliciesState(agent, nil)
+	return l.svc.GetPoliciesState(ctx, agent)
 }
 
 func NewLoggingMiddleware(svc fleet.Service, logger *zap.Logger) fleet.Service {

--- a/fleet/api/http/metrics.go
+++ b/fleet/api/http/metrics.go
@@ -380,7 +380,7 @@ func (m metricsMiddleware) RemoveAgent(ctx context.Context, token string, thingI
 	return m.svc.RemoveAgent(ctx, token, thingID)
 }
 
-func (m metricsMiddleware) GetPoliciesState(agent fleet.Agent, ctx context.Context) (map[string]interface{}, error) {
+func (m metricsMiddleware) GetPoliciesState(ctx context.Context, agent fleet.Agent) (map[string]interface{}, error) {
 
 	defer func(begin time.Time) {
 		labels := []string{
@@ -395,7 +395,7 @@ func (m metricsMiddleware) GetPoliciesState(agent fleet.Agent, ctx context.Conte
 
 	}(time.Now())
 
-	return m.svc.GetPoliciesState(agent, nil)
+	return m.svc.GetPoliciesState(nil, agent)
 }
 
 func (m metricsMiddleware) identify(token string) (string, error) {

--- a/fleet/api/http/metrics.go
+++ b/fleet/api/http/metrics.go
@@ -384,7 +384,7 @@ func (m metricsMiddleware) GetPoliciesState(ctx context.Context, agent fleet.Age
 
 	defer func(begin time.Time) {
 		labels := []string{
-			"method", "getPolicyState",
+			"method", "getPoliciesState",
 			"owner_id", agent.MFOwnerID,
 			"agent_id", agent.MFThingID,
 			"group_id", "",
@@ -395,7 +395,7 @@ func (m metricsMiddleware) GetPoliciesState(ctx context.Context, agent fleet.Age
 
 	}(time.Now())
 
-	return m.svc.GetPoliciesState(nil, agent)
+	return m.svc.GetPoliciesState(ctx, agent)
 }
 
 func (m metricsMiddleware) identify(token string) (string, error) {

--- a/fleet/api/http/metrics.go
+++ b/fleet/api/http/metrics.go
@@ -380,11 +380,11 @@ func (m metricsMiddleware) RemoveAgent(ctx context.Context, token string, thingI
 	return m.svc.RemoveAgent(ctx, token, thingID)
 }
 
-func (m metricsMiddleware) GetPoliciesState(ctx context.Context, agent fleet.Agent) (map[string]interface{}, error) {
+func (m metricsMiddleware) GetPolicyState(ctx context.Context, agent fleet.Agent) (map[string]interface{}, error) {
 
 	defer func(begin time.Time) {
 		labels := []string{
-			"method", "getPoliciesState",
+			"method", "getPolicyState",
 			"owner_id", agent.MFOwnerID,
 			"agent_id", agent.MFThingID,
 			"group_id", "",
@@ -395,7 +395,7 @@ func (m metricsMiddleware) GetPoliciesState(ctx context.Context, agent fleet.Age
 
 	}(time.Now())
 
-	return m.svc.GetPoliciesState(ctx, agent)
+	return m.svc.GetPolicyState(ctx, agent)
 }
 
 func (m metricsMiddleware) identify(token string) (string, error) {

--- a/fleet/api/http/metrics.go
+++ b/fleet/api/http/metrics.go
@@ -380,6 +380,24 @@ func (m metricsMiddleware) RemoveAgent(ctx context.Context, token string, thingI
 	return m.svc.RemoveAgent(ctx, token, thingID)
 }
 
+func (m metricsMiddleware) GetPoliciesState(agent fleet.Agent, ctx context.Context) (map[string]interface{}, error) {
+
+	defer func(begin time.Time) {
+		labels := []string{
+			"method", "getPolicyState",
+			"owner_id", agent.MFOwnerID,
+			"agent_id", agent.MFThingID,
+			"group_id", "",
+		}
+
+		m.counter.With(labels...).Add(1)
+		m.latency.With(labels...).Observe(float64(time.Since(begin).Microseconds()))
+
+	}(time.Now())
+
+	return m.svc.GetPoliciesState(agent, nil)
+}
+
 func (m metricsMiddleware) identify(token string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/fleet/api/http/responses.go
+++ b/fleet/api/http/responses.go
@@ -70,7 +70,7 @@ type agentRes struct {
 	LastHBData    types.Metadata `json:"last_hb_data"`
 	TsCreated     time.Time      `json:"ts_created"`
 	TsLastHB      time.Time      `json:"ts_last_hb"`
-	PolicyStatus  types.Metadata `json:"policy_status,omitempty"`
+	PolicyState   types.Metadata `json:"policy_state,omitempty"`
 	created       bool
 }
 

--- a/fleet/api/http/responses.go
+++ b/fleet/api/http/responses.go
@@ -59,18 +59,19 @@ func (res agentGroupsPageRes) Empty() bool {
 }
 
 type agentRes struct {
-	ID             string         `json:"id"`
-	Name           string         `json:"name"`
-	State          string         `json:"state"`
-	Key            string         `json:"key,omitempty"`
-	ChannelID      string         `json:"channel_id,omitempty"`
-	AgentTags      types.Tags     `json:"agent_tags"`
-	OrbTags        types.Tags     `json:"orb_tags"`
-	AgentMetadata  types.Metadata `json:"agent_metadata"`
-	LastHBData     types.Metadata `json:"last_hb_data"`
-	TsCreated      time.Time      `json:"ts_created"`
-	TsLastHB       time.Time      `json:"ts_last_hb"`
-	created        bool
+	ID            string         `json:"id"`
+	Name          string         `json:"name"`
+	State         string         `json:"state"`
+	Key           string         `json:"key,omitempty"`
+	ChannelID     string         `json:"channel_id,omitempty"`
+	AgentTags     types.Tags     `json:"agent_tags"`
+	OrbTags       types.Tags     `json:"orb_tags"`
+	AgentMetadata types.Metadata `json:"agent_metadata"`
+	LastHBData    types.Metadata `json:"last_hb_data"`
+	TsCreated     time.Time      `json:"ts_created"`
+	TsLastHB      time.Time      `json:"ts_last_hb"`
+	PolicyStatus  types.Metadata `json:"policy_status,omitempty"`
+	created       bool
 }
 
 func (s agentRes) Code() int {

--- a/fleet/api/http/responses.go
+++ b/fleet/api/http/responses.go
@@ -70,7 +70,7 @@ type agentRes struct {
 	LastHBData    types.Metadata `json:"last_hb_data"`
 	TsCreated     time.Time      `json:"ts_created"`
 	TsLastHB      time.Time      `json:"ts_last_hb"`
-	PolicyState   types.Metadata `json:"policy_state,omitempty"`
+	PoliciesState types.Metadata `json:"policies_state,omitempty"`
 	created       bool
 }
 

--- a/fleet/api/http/responses.go
+++ b/fleet/api/http/responses.go
@@ -70,7 +70,7 @@ type agentRes struct {
 	LastHBData    types.Metadata `json:"last_hb_data"`
 	TsCreated     time.Time      `json:"ts_created"`
 	TsLastHB      time.Time      `json:"ts_last_hb"`
-	PoliciesState types.Metadata `json:"policies_state,omitempty"`
+	PolicyState   types.Metadata `json:"policy_state,omitempty"`
 	created       bool
 }
 

--- a/fleet/comms_types.go
+++ b/fleet/comms_types.go
@@ -54,7 +54,7 @@ type BackendStateInfo struct {
 
 type PolicyStateInfo struct {
 	Name     string   `json:"name"`
-	Datasets []string `json:"datasets"`
+	Datasets []string `json:"datasets,omitempty"`
 	State    string   `json:"state"`
 	Error    string   `json:"error,omitempty"`
 }

--- a/fleet/comms_types.go
+++ b/fleet/comms_types.go
@@ -65,10 +65,10 @@ type GroupStateInfo struct {
 }
 
 type Heartbeat struct {
-	SchemaVersion string                      `json:"schema_version" mapstructure:"schema_version"`
-	TimeStamp     time.Time                   `json:"ts" mapstructure:"ts"`
-	State         State                       `json:"state" mapstruct:"state"`
-	BackendState  map[string]BackendStateInfo `json:"backend_state" mapstructure:"backend_state"`
-	PolicyState   map[string]PolicyStateInfo  `json:"policy_state" mapstructure:"policy_state"`
-	GroupState    map[string]GroupStateInfo   `json:"group_state" mapstructure:"group_state"`
+	SchemaVersion string                      `json:"schema_version"`
+	TimeStamp     time.Time                   `json:"ts"`
+	State         State                       `json:"state"`
+	BackendState  map[string]BackendStateInfo `json:"backend_state"`
+	PolicyState   map[string]PolicyStateInfo  `json:"policy_state"`
+	GroupState    map[string]GroupStateInfo   `json:"group_state"`
 }

--- a/fleet/comms_types.go
+++ b/fleet/comms_types.go
@@ -65,10 +65,10 @@ type GroupStateInfo struct {
 }
 
 type Heartbeat struct {
-	SchemaVersion string                      `json:"schema_version"`
-	TimeStamp     time.Time                   `json:"ts"`
-	State         State                       `json:"state"`
-	BackendState  map[string]BackendStateInfo `json:"backend_state"`
-	PolicyState   map[string]PolicyStateInfo  `json:"policy_state"`
-	GroupState    map[string]GroupStateInfo   `json:"group_state"`
+	SchemaVersion string                      `json:"schema_version" mapstructure:"schema_version"`
+	TimeStamp     time.Time                   `json:"ts" mapstructure:"ts"`
+	State         State                       `json:"state" mapstruct:"state"`
+	BackendState  map[string]BackendStateInfo `json:"backend_state" mapstructure:"backend_state"`
+	PolicyState   map[string]PolicyStateInfo  `json:"policy_state" mapstructure:"policy_state"`
+	GroupState    map[string]GroupStateInfo   `json:"group_state" mapstructure:"group_state"`
 }

--- a/fleet/redis/producer/streams.go
+++ b/fleet/redis/producer/streams.go
@@ -125,6 +125,10 @@ func (es eventStore) RemoveAgent(ctx context.Context, token, thingID string) (er
 	return es.svc.RemoveAgent(ctx, token, thingID)
 }
 
+func (es eventStore) GetPoliciesState(agent fleet.Agent, ctx context.Context) (map[string]interface{}, error) {
+	return es.svc.GetPoliciesState(agent, nil)
+}
+
 // NewEventStoreMiddleware returns wrapper around fleet service that sends
 // events to event store.
 func NewEventStoreMiddleware(svc fleet.Service, client *redis.Client) fleet.Service {

--- a/fleet/redis/producer/streams.go
+++ b/fleet/redis/producer/streams.go
@@ -125,8 +125,8 @@ func (es eventStore) RemoveAgent(ctx context.Context, token, thingID string) (er
 	return es.svc.RemoveAgent(ctx, token, thingID)
 }
 
-func (es eventStore) GetPoliciesState(ctx context.Context, agent fleet.Agent) (map[string]interface{}, error) {
-	return es.svc.GetPoliciesState(ctx, agent)
+func (es eventStore) GetPolicyState(ctx context.Context, agent fleet.Agent) (map[string]interface{}, error) {
+	return es.svc.GetPolicyState(ctx, agent)
 }
 
 // NewEventStoreMiddleware returns wrapper around fleet service that sends

--- a/fleet/redis/producer/streams.go
+++ b/fleet/redis/producer/streams.go
@@ -125,8 +125,8 @@ func (es eventStore) RemoveAgent(ctx context.Context, token, thingID string) (er
 	return es.svc.RemoveAgent(ctx, token, thingID)
 }
 
-func (es eventStore) GetPoliciesState(agent fleet.Agent, ctx context.Context) (map[string]interface{}, error) {
-	return es.svc.GetPoliciesState(agent, nil)
+func (es eventStore) GetPoliciesState(ctx context.Context, agent fleet.Agent) (map[string]interface{}, error) {
+	return es.svc.GetPoliciesState(ctx, agent)
 }
 
 // NewEventStoreMiddleware returns wrapper around fleet service that sends


### PR DESCRIPTION
Adds the following map structure field to response of agent list endpoint, in which the key is the policy ID and the value is the policy information. All retrieve from lastHBData on DB

``
   "policy_status": {
      "43230fb0-9b28-d73c-0d40-efc8446bcfe8":{
          "name": "test",
          "status": "running"
      }
   }
``
![image](https://user-images.githubusercontent.com/86990690/172955154-5b46a634-5f7c-4ad9-8e86-76a38062afd0.png)
