### PR TITLE
fix(agent): remove the ConnectRetry behavior from paho client.

### DIFF
--- a/agent/comms.go
+++ b/agent/comms.go
@@ -25,8 +25,6 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 	})
 	opts.SetPingTimeout(5 * time.Second)
 	opts.SetAutoReconnect(true)
-	opts.SetConnectRetry(true)
-	opts.SetConnectRetryInterval(5 * time.Second)
 	opts.SetOnConnectHandler(func(client mqtt.Client) {
 		a.requestReconnection(client, config)
 	})


### PR DESCRIPTION
Signed-off-by: Luiz Pegoraro <luiz.pegoraro@encora.com>

This relates to the issue #1334 