### PR TITLE
fix(agent/fleet): Remove the state update on the handleCapabilities flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ define run_test
 endef
 
 define make_docker
-	$(shell [ -z "$(SERVICE)" ] && SERVICE=$(subst docker_,,$(1)))
+	$(eval SERVICE=$(shell [ -z "$(SERVICE)" ] && echo $(subst docker_,,$(1)) || echo $(SERVICE)))
 	docker build \
 		--no-cache \
 		--build-arg SVC=$(SERVICE) \
@@ -50,11 +50,11 @@ define make_docker
 		--tag=$(DOCKERHUB_REPO)/$(DOCKER_IMAGE_NAME_PREFIX)-$(SERVICE):$(ORB_VERSION) \
 		--tag=$(DOCKERHUB_REPO)/$(DOCKER_IMAGE_NAME_PREFIX)-$(SERVICE):$(ORB_VERSION)-$(COMMIT_HASH) \
 		-f docker/Dockerfile .
+	$(eval SERVICE="")
 endef
 
 define make_docker_dev
-	$(eval svc=$(subst docker_dev_,,$(1)))
-
+	$(eval svc=$(shell [ -z "$(svc)" ] && echo $(subst docker_,,$(1)) || echo $(svc)))
 	docker build \
 		--no-cache \
 		--build-arg SVC=$(svc) \
@@ -62,6 +62,7 @@ define make_docker_dev
 		--tag=$(DOCKERHUB_REPO)/$(DOCKER_IMAGE_NAME_PREFIX)-$(svc):$(ORB_VERSION) \
 		--tag=$(DOCKERHUB_REPO)/$(DOCKER_IMAGE_NAME_PREFIX)-$(svc):$(ORB_VERSION)-$(COMMIT_HASH) \
 		-f docker/Dockerfile.dev ./build
+	$(eval svc="")
 endef
 
 all: platform

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -25,9 +25,6 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 	})
 	opts.SetPingTimeout(5 * time.Second)
 	opts.SetAutoReconnect(true)
-	opts.SetOnConnectHandler(func(client mqtt.Client) {
-		a.requestReconnection(client, config)
-	})
 
 	if !a.config.OrbAgent.TLS.Verify {
 		opts.TLSConfig = &tls.Config{InsecureSkipVerify: true}
@@ -112,6 +109,7 @@ func (a *orbAgent) startComms(config config.MQTTConfig) error {
 			return ErrMqttConnection
 		}
 	}
+	a.requestReconnection(a.client, config)
 
 	return nil
 }

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -25,8 +25,6 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 	})
 	opts.SetPingTimeout(5 * time.Second)
 	opts.SetAutoReconnect(true)
-	opts.SetConnectRetry(true)
-	opts.SetConnectRetryInterval(5 * time.Second)
 	opts.SetOnConnectHandler(func(client mqtt.Client) {
 		a.requestReconnection(client, config)
 	})

--- a/fleet/comms.go
+++ b/fleet/comms.go
@@ -557,7 +557,6 @@ func (svc fleetCommsService) handleHeartbeat(thingID string, channelID string, p
 		agent.LastHBData["backend_state"] = hb.BackendState
 		agent.LastHBData["policy_state"] = hb.PolicyState
 		agent.LastHBData["group_state"] = hb.GroupState
-
 	}
 	err := svc.agentRepo.UpdateHeartbeatByIDWithChannel(context.Background(), agent)
 	if err != nil {

--- a/fleet/comms.go
+++ b/fleet/comms.go
@@ -495,13 +495,17 @@ func (svc fleetCommsService) handleCapabilities(thingID string, channelID string
 	if err := json.Unmarshal(payload, &capabilities); err != nil {
 		return ErrSchemaMalformed
 	}
-	agent := Agent{MFThingID: thingID, MFChannelID: channelID}
+
+	agent, err := svc.agentRepo.RetrieveByIDWithChannel(context.Background(), thingID, channelID)
+	if err != nil {
+		agent = Agent{MFThingID: thingID, MFChannelID: channelID}
+	}
 	agent.AgentMetadata = make(map[string]interface{})
 	agent.AgentMetadata["backends"] = capabilities.Backends
 	agent.AgentMetadata["orb_agent"] = capabilities.OrbAgent
 	agent.AgentTags = capabilities.AgentTags
 
-	err := svc.checkVersion(buildinfo.GetMinAgentVersion(), capabilities.OrbAgent.Version, &agent)
+	err = svc.checkVersion(buildinfo.GetMinAgentVersion(), capabilities.OrbAgent.Version, &agent)
 	if err != nil {
 		return err
 	}

--- a/fleet/postgres/agents.go
+++ b/fleet/postgres/agents.go
@@ -216,9 +216,10 @@ func (r agentRepository) RetrieveAll(ctx context.Context, owner string, pm fleet
 }
 
 func (r agentRepository) UpdateDataByIDWithChannel(ctx context.Context, agent fleet.Agent) error {
-	q := fmt.Sprintf(`UPDATE agents SET (agent_tags, agent_metadata)         
-			= (:agent_tags, :agent_metadata) 
-			WHERE mf_thing_id = :mf_thing_id AND mf_channel_id = :mf_channel_id;`)
+	stateColumn, stateValue := getStateParam(agent.State.String())
+	q := fmt.Sprintf(`UPDATE agents SET (agent_tags, agent_metadata %s)         
+			= (:agent_tags, :agent_metadata %s) 
+			WHERE mf_thing_id = :mf_thing_id AND mf_channel_id = :mf_channel_id;`, stateColumn, stateValue)
 
 	if agent.MFThingID == "" || agent.MFChannelID == "" {
 		return errors.ErrMalformedEntity

--- a/fleet/postgres/agents.go
+++ b/fleet/postgres/agents.go
@@ -216,10 +216,9 @@ func (r agentRepository) RetrieveAll(ctx context.Context, owner string, pm fleet
 }
 
 func (r agentRepository) UpdateDataByIDWithChannel(ctx context.Context, agent fleet.Agent) error {
-	stateColumn, stateValue := getStateParam(agent.State.String())
-	q := fmt.Sprintf(`UPDATE agents SET (agent_tags, agent_metadata %s)         
-			= (:agent_tags, :agent_metadata %s) 
-			WHERE mf_thing_id = :mf_thing_id AND mf_channel_id = :mf_channel_id;`, stateColumn, stateValue)
+	q := fmt.Sprintf(`UPDATE agents SET (agent_tags, agent_metadata)         
+			= (:agent_tags, :agent_metadata) 
+			WHERE mf_thing_id = :mf_thing_id AND mf_channel_id = :mf_channel_id;`)
 
 	if agent.MFThingID == "" || agent.MFChannelID == "" {
 		return errors.ErrMalformedEntity

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ns1labs/orb
 go 1.17
 
 require (
-	github.com/eclipse/paho.mqtt.golang v1.3.5
+	github.com/eclipse/paho.mqtt.golang v1.4.1
 	github.com/fatih/structs v1.1.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-cmd/cmd v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -455,8 +455,8 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
-github.com/eclipse/paho.mqtt.golang v1.3.5 h1:sWtmgNxYM9P2sP+xEItMozsR3w0cqZFlqnNN1bdl41Y=
-github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=
+github.com/eclipse/paho.mqtt.golang v1.4.1 h1:tUSpviiL5G3P9SZZJPC4ZULZJsxQKXxfENpMvdbAXAI=
+github.com/eclipse/paho.mqtt.golang v1.4.1/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=

--- a/python-test/features/integration.feature
+++ b/python-test/features/integration.feature
@@ -706,7 +706,7 @@ Scenario: Remotely restart agents with policies applied
         And the container logs that were output after reset the agent contain the message "removing policies" within 5 seconds
         And the container logs that were output after reset the agent contain the message "resetting backend" within 10 seconds
         And the container logs that were output after reset the agent contain the message "reapplying policies" within 5 seconds
-        And the container logs that were output after reset the agent contain the message "all backends were restarted" within 5 seconds
+        And the container logs that were output after reset the agent contain the message "all backends and comms were restarted" within 5 seconds
         And the container logs that were output after reset the agent contain the message "policy applied successfully" referred to each applied policy within 10 seconds
         And the container logs that were output after reset the agent contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
 
@@ -721,7 +721,7 @@ Scenario: Remotely restart agents without policies applied
     When remotely restart the agent
         And the container logs that were output after reset the agent contain the message "resetting backend" within 5 seconds
         And the container logs that were output after reset the agent contain the message "pktvisor process stopped" within 5 seconds
-        And the container logs that were output after reset the agent contain the message "all backends were restarted" within 5 seconds
+        And the container logs that were output after reset the agent contain the message "all backends and comms were restarted" within 5 seconds
         And 2 simple policies are applied to the group
     Then the container logs should contain the message "restarting all backends" within 5 seconds
         And this agent's heartbeat shows that 2 policies are successfully applied and has status running


### PR DESCRIPTION
Removes the state update when the Agent communicates the capabilities to Fleet. 
agent.State should only change in the Heartbeat flow