### PR TITLE
feat(agent): enable resumeSub

### DIFF
--- a/agent/comms.go
+++ b/agent/comms.go
@@ -23,6 +23,7 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 	opts.SetDefaultPublishHandler(func(client mqtt.Client, message mqtt.Message) {
 		a.logger.Info("message on unknown channel, ignoring", zap.String("topic", message.Topic()), zap.ByteString("payload", message.Payload()))
 	})
+	opts.SetResumeSubs(true)
 	opts.SetConnectionLostHandler(func(client mqtt.Client, err error) {
 		a.logger.Error("error on connection lost, retrying to reconnect", zap.Error(err))
 		if err = a.restartComms(); err != nil {


### PR DESCRIPTION
Enabling ResumeSubs in reconnecting.

This is recommended and not sure why it is not true by default on the mqtt client.

```json
{
    "level": "error",
    "ts": 1656378463.0370817,
    "caller": "agent/comms.go:55",
    "msg": "failed to subscribe to RPC topic",
    "topic": "channels/11a121ec-144b-45a0-9d6f-414ee5262063/messages/fromcore",
    "error": "not currently connected and ResumeSubs not set",
    "stacktrace": "github.com/ns1labs/orb/agent.(*orbAgent).requestReconnection
        /go/src/github.com/ns1labs/orb/agent/comms.go:55\ngithub.com/ns1labs/orb/agent.(*orbAgent).startComms
        /go/src/github.com/ns1labs/orb/agent/comms.go:120\ngithub.com/ns1labs/orb/agent.(*orbAgent).restartComms
        /go/src/github.com/ns1labs/orb/agent/agent.go:205\ngithub.com/ns1labs/orb/agent.(*orbAgent).connect.func2
        /go/src/github.com/ns1labs/orb/agent/comms.go:28"
}
```

