### PR TITLE
feat(sinker): add debug and omitempty unset metrics from pktvisor

### DIFF
--- a/sinker/backend/pktvisor/pktvisor.go
+++ b/sinker/backend/pktvisor/pktvisor.go
@@ -67,7 +67,6 @@ func (p pktvisorBackend) ProcessMetrics(agent *pb.AgentInfoRes, agentID string, 
 	}
 	stats := StatSnapshot{}
 	for _, handlerData := range metrics {
-		p.logger.Debug("debugging handlerData", zap.Reflect("handlerData", handlerData))
 		if data, ok := handlerData["pcap"]; ok {
 			err := mapstructure.Decode(data, &stats.Pcap)
 			if err != nil {

--- a/sinker/backend/pktvisor/pktvisor.go
+++ b/sinker/backend/pktvisor/pktvisor.go
@@ -67,6 +67,7 @@ func (p pktvisorBackend) ProcessMetrics(agent *pb.AgentInfoRes, agentID string, 
 	}
 	stats := StatSnapshot{}
 	for _, handlerData := range metrics {
+		p.logger.Debug("debugging handlerData", zap.Reflect("handlerData", handlerData))
 		if data, ok := handlerData["pcap"]; ok {
 			err := mapstructure.Decode(data, &stats.Pcap)
 			if err != nil {
@@ -105,7 +106,9 @@ func (p pktvisorBackend) ProcessMetrics(agent *pb.AgentInfoRes, agentID string, 
 func parseToProm(ctxt *context, stats StatSnapshot) prometheus.TSList {
 	var tsList = prometheus.TSList{}
 	statsMap := structs.Map(stats)
+	ctxt.logger.Debug("debugging stats map", zap.Reflect("statsMap", statsMap))
 	convertToPromParticle(ctxt, statsMap, "", &tsList)
+	ctxt.logger.Debug("debugging tsList map", zap.Reflect("statsMap", statsMap))
 	return tsList
 }
 

--- a/sinker/backend/pktvisor/pktvisor.go
+++ b/sinker/backend/pktvisor/pktvisor.go
@@ -106,9 +106,8 @@ func (p pktvisorBackend) ProcessMetrics(agent *pb.AgentInfoRes, agentID string, 
 func parseToProm(ctxt *context, stats StatSnapshot) prometheus.TSList {
 	var tsList = prometheus.TSList{}
 	statsMap := structs.Map(stats)
-	ctxt.logger.Debug("debugging stats map", zap.Reflect("statsMap", statsMap))
 	convertToPromParticle(ctxt, statsMap, "", &tsList)
-	ctxt.logger.Debug("debugging tsList map", zap.Reflect("statsMap", statsMap))
+	ctxt.logger.Debug("debugging converted statsMap", zap.Reflect("statsMap", statsMap))
 	return tsList
 }
 

--- a/sinker/backend/pktvisor/pktvisor_test.go
+++ b/sinker/backend/pktvisor/pktvisor_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestDHCPConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()
@@ -235,7 +235,7 @@ func TestDHCPConversion(t *testing.T) {
 }
 
 func TestASNConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()
@@ -339,7 +339,7 @@ func TestASNConversion(t *testing.T) {
 }
 
 func TestGeoLocConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()
@@ -443,7 +443,7 @@ func TestGeoLocConversion(t *testing.T) {
 }
 
 func TestPCAPConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()
@@ -577,7 +577,7 @@ func TestPCAPConversion(t *testing.T) {
 }
 
 func TestDNSConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()
@@ -763,7 +763,7 @@ func TestDNSConversion(t *testing.T) {
 }
 
 func TestDNSRatesConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()
@@ -1115,7 +1115,7 @@ func TestDNSRatesConversion(t *testing.T) {
 }
 
 func TestDNSTopKMetricsConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()
@@ -1419,7 +1419,7 @@ func TestDNSTopKMetricsConversion(t *testing.T) {
 }
 
 func TestDNSWirePacketsConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()
@@ -1727,7 +1727,7 @@ func TestDNSWirePacketsConversion(t *testing.T) {
 }
 
 func TestDNSXactConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()
@@ -1957,7 +1957,7 @@ func TestDNSXactConversion(t *testing.T) {
 }
 
 func TestPacketsConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()
@@ -2300,7 +2300,7 @@ func TestPacketsConversion(t *testing.T) {
 }
 
 func TestPeriodConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()
@@ -2509,7 +2509,7 @@ func TestPeriodConversion(t *testing.T) {
 }
 
 func TestFlowCardinalityConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()
@@ -2680,7 +2680,7 @@ func TestFlowCardinalityConversion(t *testing.T) {
 }
 
 func TestFlowConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()
@@ -2928,7 +2928,7 @@ func TestFlowConversion(t *testing.T) {
 }
 
 func TestFlowTopKMetricsConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()
@@ -3781,7 +3781,7 @@ func TestFlowTopKMetricsConversion(t *testing.T) {
 }
 
 func TestAgentTagsConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()
@@ -3890,11 +3890,10 @@ func TestAgentTagsConversion(t *testing.T) {
 			assert.Equal(t, c.expected.Datapoint.Value, receivedDatapoint.Value, fmt.Sprintf("%s: expected value %f got %f", desc, c.expected.Datapoint.Value, receivedDatapoint.Value))
 		})
 	}
-
 }
 
 func TestTagsConversion(t *testing.T) {
-	var logger *zap.Logger
+	var logger = zap.NewNop()
 	pktvisor.Register(logger)
 
 	ownerID, err := uuid.NewV4()

--- a/sinker/backend/pktvisor/types.go
+++ b/sinker/backend/pktvisor/types.go
@@ -203,9 +203,9 @@ type FlowPayload struct {
 
 // StatSnapshot is a snapshot of a given period from pktvisord
 type StatSnapshot struct {
-	DNS     DNSPayload    `mapstructure:"DNS,omitempty"`
-	DHCP    DHCPPayload   `mapstructure:"DHCP,omitempty"`
-	Packets PacketPayload `mapstructure:"Packets,omitempty"`
-	Pcap    PcapPayload   `mapstructure:"Pcap,omitempty"`
-	Flow    FlowPayload   `mapstructure:"Flow,omitempty"`
+	DNS     *DNSPayload    `mapstructure:"DNS,omitempty"`
+	DHCP    *DHCPPayload   `mapstructure:"DHCP,omitempty"`
+	Packets *PacketPayload `mapstructure:"Packets,omitempty"`
+	Pcap    *PcapPayload   `mapstructure:"Pcap,omitempty"`
+	Flow    *FlowPayload   `mapstructure:"Flow,omitempty"`
 }

--- a/sinker/backend/pktvisor/types.go
+++ b/sinker/backend/pktvisor/types.go
@@ -203,9 +203,9 @@ type FlowPayload struct {
 
 // StatSnapshot is a snapshot of a given period from pktvisord
 type StatSnapshot struct {
-	DNS     DNSPayload
-	DHCP    DHCPPayload
-	Packets PacketPayload
-	Pcap    PcapPayload
-	Flow    FlowPayload
+	DNS     DNSPayload    `mapstructure:"DNS,omitempty"`
+	DHCP    DHCPPayload   `mapstructure:"DHCP,omitempty"`
+	Packets PacketPayload `mapstructure:"Packets,omitempty"`
+	Pcap    PcapPayload   `mapstructure:"Pcap,omitempty"`
+	Flow    FlowPayload   `mapstructure:"Flow,omitempty"`
 }


### PR DESCRIPTION
See how it was before below this version:

## After
```json
{
    "level": "debug",
    "ts": 1656702342.879576,
    "caller": "pktvisor/pktvisor.go:109",
    "msg": "debugging converted statsMap",
    "statsMap": {
        "DHCP": null,
        "DNS": {
            "Cardinality": {
                "Qname": 14
            },
            "Period": {
                "Length": 60,
                "StartTS": 1656701788
            },
            "Rates": {
                "Total": {
                    "Live": 0,
                    "P50": 0,
                    "P90": 8,
                    "P95": 16,
                    "P99": 37
                }
            },
            "TopNxdomain": [
                {
                    "Estimate": 4,
                    "Name": "kubernetes.default.svc"
                },
                {
                    "Estimate": 2,
                    "Name": "connectivity-check.ubuntu.com.hitronhub.home"
                }
            ],
            "TopQname2": [
                {
                    "Estimate": 54,
                    "Name": ".ubuntu.com"
                },
                {
                    "Estimate": 30,
                    "Name": "ipv4only.arpa"
                },
                {
                    "Estimate": 12,
                    "Name": ".azure.com"
                },
                {
                    "Estimate": 8,
                    "Name": ".trafficmanager.net"
                },
                {
                    "Estimate": 8,
                    "Name": ".default.svc"
                },
                {
                    "Estimate": 4,
                    "Name": ".hitronhub.home"
                },
                {
                    "Estimate": 4,
                    "Name": ".mozilla.com"
                },
                {
                    "Estimate": 4,
                    "Name": ".microsoft.com"
                },
                {
                    "Estimate": 4,
                    "Name": ".firefox.com"
                },
                {
                    "Estimate": 2,
                    "Name": ".mozaws.net"
                }
            ],
            "TopQname3": [
                {
                    "Estimate": 50,
                    "Name": "daisy.ubuntu.com"
                },
                {
                    "Estimate": 12,
                    "Name": ".cloudapp.azure.com"
                },
                {
                    "Estimate": 8,
                    "Name": "kubernetes.default.svc"
                },
                {
                    "Estimate": 4,
                    "Name": "westus2cns-prod-2.trafficmanager.net"
                },
                {
                    "Estimate": 4,
                    "Name": ".data.microsoft.com"
                },
                {
                    "Estimate": 4,
                    "Name": ".com.hitronhub.home"
                },
                {
                    "Estimate": 4,
                    "Name": ".services.mozilla.com"
                },
                {
                    "Estimate": 4,
                    "Name": "connectivity-check.ubuntu.com"
                },
                {
                    "Estimate": 4,
                    "Name": ".sfb.trafficmanager.net"
                },
                {
                    "Estimate": 4,
                    "Name": "detectportal.firefox.com"
                }
            ],
            "TopQtype": [
                {
                    "Estimate": 114,
                    "Name": "AAAA"
                },
                {
                    "Estimate": 16,
                    "Name": "A"
                }
            ],
            "TopREFUSED": [],
            "TopRcode": [
                {
                    "Estimate": 59,
                    "Name": "NOERROR"
                },
                {
                    "Estimate": 6,
                    "Name": "NXDOMAIN"
                }
            ],
            "TopSRVFAIL": [],
            "TopUDPPorts": [
                {
                    "Estimate": 4,
                    "Name": "53560"
                },
                {
                    "Estimate": 4,
                    "Name": "33403"
                },
                {
                    "Estimate": 4,
                    "Name": "45573"
                },
                {
                    "Estimate": 2,
                    "Name": "60445"
                },
                {
                    "Estimate": 2,
                    "Name": "58421"
                },
                {
                    "Estimate": 2,
                    "Name": "58216"
                },
                {
                    "Estimate": 2,
                    "Name": "42053"
                },
                {
                    "Estimate": 2,
                    "Name": "58486"
                },
                {
                    "Estimate": 2,
                    "Name": "52139"
                },
                {
                    "Estimate": 2,
                    "Name": "49909"
                }
            ],
            "WirePackets": {
                "Ipv4": 130,
                "Ipv6": 0,
                "Noerror": 59,
                "Nxdomain": 6,
                "Queries": 65,
                "Refused": 0,
                "Replies": 65,
                "Srvfail": 0,
                "TCP": 0,
                "Total": 130,
                "UDP": 130
            },
            "Xact": {
                "Counts": {
                    "TimedOut": 0,
                    "Total": 65
                },
                "In": {
                    "QuantilesUS": {
                        "P50": 0,
                        "P90": 0,
                        "P95": 0,
                        "P99": 0
                    },
                    "TopSlow": [],
                    "Total": 0
                },
                "Out": {
                    "QuantilesUS": {
                        "P50": 22776,
                        "P90": 44081,
                        "P95": 151296,
                        "P99": 368817
                    },
                    "TopSlow": [
                        {
                            "Estimate": 6,
                            "Name": "daisy.ubuntu.com"
                        },
                        {
                            "Estimate": 6,
                            "Name": "ipv4only.arpa"
                        },
                        {
                            "Estimate": 2,
                            "Name": "westus2cns-prod-2.trafficmanager.net"
                        },
                        {
                            "Estimate": 2,
                            "Name": "westus2cns-prod-2-1.westus2.cloudapp.azure.com"
                        },
                        {
                            "Estimate": 2,
                            "Name": "kubernetes.default.svc"
                        },
                        {
                            "Estimate": 2,
                            "Name": "presence.services.sfb.trafficmanager.net"
                        },
                        {
                            "Estimate": 1,
                            "Name": "teams.events.data.microsoft.com"
                        },
                        {
                            "Estimate": 1,
                            "Name": "locprod2-elb-us-west-2.prod.mozaws.net"
                        }
                    ],
                    "Total": 65
                }
            }
        },
        "Flow": null,
        "Packets": {
            "Cardinality": {
                "DstIpsOut": 1,
                "SrcIpsIn": 1
            },
            "DeepSamples": 130,
            "In": 65,
            "Ipv4": 130,
            "Ipv6": 0,
            "OtherL4": 0,
            "Out": 65,
            "Period": {
                "Length": 60,
                "StartTS": 1656701788
            },
            "Rates": {
                "Pps_in": {
                    "Live": 0,
                    "P50": 0,
                    "P90": 4,
                    "P95": 8,
                    "P99": 18
                },
                "Pps_out": {
                    "Live": 0,
                    "P50": 0,
                    "P90": 4,
                    "P95": 8,
                    "P99": 19
                },
                "Pps_total": {
                    "Live": 0,
                    "P50": 0,
                    "P90": 8,
                    "P95": 16,
                    "P99": 37
                }
            },
            "TCP": 0,
            "TopASN": [],
            "TopGeoLoc": [],
            "TopIpv4": [
                {
                    "Estimate": 130,
                    "Name": "181.213.132.2"
                }
            ],
            "TopIpv6": [],
            "Total": 130,
            "UDP": 130
        },
        "Pcap": null
    }
}
```

I am checking if I am able to not send the "null" ones.


## Before
```json
{
    "level": "debug",
    "ts": 1656691569.321574,
    "caller": "pktvisor/pktvisor.go:110",
    "msg": "debugging tsList map",
    "statsMap": {
        "DHCP": {
            "Period": {
                "Length": 0,
                "StartTS": 0
            },
            "Rates": {
                "Total": {
                    "Live": 0,
                    "P50": 0,
                    "P90": 0,
                    "P95": 0,
                    "P99": 0
                }
            },
            "WirePackets": {
                "Ack": 0,
                "DeepSamples": 0,
                "Discover": 0,
                "Filtered": 0,
                "Offer": 0,
                "Request": 0,
                "Total": 0
            }
        },
        "DNS": {
            "Cardinality": {
                "Qname": 60
            },
            "Period": {
                "Length": 62,
                "StartTS": 1656691477
            },
            "Rates": {
                "Total": {
                    "Live": 0,
                    "P50": 0,
                    "P90": 11,
                    "P95": 14,
                    "P99": 54
                }
            },
            "TopNxdomain": [
                {
                    "Estimate": 8,
                    "Name": "br-intranet.daitan.com.hitronhub.home"
                },
                {
                    "Estimate": 8,
                    "Name": "br-intranet.daitan.com"
                }
            ],
            "TopQname2": [
                {
                    "Estimate": 42,
                    "Name": ".mozilla.com"
                },
                {
                    "Estimate": 16,
                    "Name": ".hitronhub.home"
                },
                {
                    "Estimate": 16,
                    "Name": ".daitan.com"
                },
                {
                    "Estimate": 14,
                    "Name": ".google.com"
                },
                {
                    "Estimate": 12,
                    "Name": ".microsoft.com"
                },
                {
                    "Estimate": 12,
                    "Name": ".googlevideo.com"
                },
                {
                    "Estimate": 12,
                    "Name": ".office.com"
                },
                {
                    "Estimate": 10,
                    "Name": ".duckduckgo.com"
                },
                {
                    "Estimate": 8,
                    "Name": ".googleapis.com"
                },
                {
                    "Estimate": 8,
                    "Name": ".doubleclick.net"
                }
            ],
            "TopQname3": [
                {
                    "Estimate": 42,
                    "Name": ".services.mozilla.com"
                },
                {
                    "Estimate": 16,
                    "Name": "br-intranet.daitan.com"
                },
                {
                    "Estimate": 16,
                    "Name": ".com.hitronhub.home"
                },
                {
                    "Estimate": 8,
                    "Name": ".teams.microsoft.com"
                },
                {
                    "Estimate": 6,
                    "Name": ".dataops.mozgcp.net"
                },
                {
                    "Estimate": 6,
                    "Name": "external-content.duckduckgo.com"
                },
                {
                    "Estimate": 4,
                    "Name": ".g.doubleclick.net"
                },
                {
                    "Estimate": 4,
                    "Name": "login.microsoftonline.com"
                },
                {
                    "Estimate": 4,
                    "Name": ".cloudapp.azure.com"
                },
                {
                    "Estimate": 4,
                    "Name": "play.google.com"
                }
            ],
            "TopQtype": [
                {
                    "Estimate": 170,
                    "Name": "AAAA"
                },
                {
                    "Estimate": 100,
                    "Name": "A"
                }
            ],
            "TopREFUSED": [],
            "TopRcode": [
                {
                    "Estimate": 119,
                    "Name": "NOERROR"
                },
                {
                    "Estimate": 16,
                    "Name": "NXDOMAIN"
                }
            ],
            "TopSRVFAIL": [],
            "TopUDPPorts": [
                {
                    "Estimate": 4,
                    "Name": "52262"
                },
                {
                    "Estimate": 4,
                    "Name": "51804"
                },
                {
                    "Estimate": 4,
                    "Name": "59916"
                },
                {
                    "Estimate": 4,
                    "Name": "59676"
                },
                {
                    "Estimate": 4,
                    "Name": "34561"
                },
                {
                    "Estimate": 4,
                    "Name": "57624"
                },
                {
                    "Estimate": 4,
                    "Name": "54625"
                },
                {
                    "Estimate": 4,
                    "Name": "52580"
                },
                {
                    "Estimate": 4,
                    "Name": "57713"
                },
                {
                    "Estimate": 2,
                    "Name": "34149"
                }
            ],
            "WirePackets": {
                "Ipv4": 0,
                "Ipv6": 270,
                "Noerror": 119,
                "Nxdomain": 16,
                "Queries": 135,
                "Refused": 0,
                "Replies": 135,
                "Srvfail": 0,
                "TCP": 0,
                "Total": 270,
                "UDP": 270
            },
            "Xact": {
                "Counts": {
                    "TimedOut": 0,
                    "Total": 135
                },
                "In": {
                    "QuantilesUS": {
                        "P50": 0,
                        "P90": 0,
                        "P95": 0,
                        "P99": 0
                    },
                    "TopSlow": [],
                    "Total": 0
                },
                "Out": {
                    "QuantilesUS": {
                        "P50": 22504,
                        "P90": 51970,
                        "P95": 146519,
                        "P99": 250792
                    },
                    "TopSlow": [
                        {
                            "Estimate": 9,
                            "Name": "sync-1-us-west1-g.sync.services.mozilla.com"
                        },
                        {
                            "Estimate": 4,
                            "Name": "br-intranet.daitan.com"
                        },
                        {
                            "Estimate": 2,
                            "Name": "links.duckduckgo.com"
                        },
                        {
                            "Estimate": 2,
                            "Name": "www.google.com.br"
                        },
                        {
                            "Estimate": 2,
                            "Name": "duckduckgo.com"
                        },
                        {
                            "Estimate": 2,
                            "Name": "orb.live"
                        },
                        {
                            "Estimate": 2,
                            "Name": "login.microsoftonline.com"
                        },
                        {
                            "Estimate": 2,
                            "Name": "play.google.com"
                        },
                        {
                            "Estimate": 2,
                            "Name": "i.ytimg.com"
                        },
                        {
                            "Estimate": 2,
                            "Name": "statics.teams.cdn.office.net"
                        }
                    ],
                    "Total": 135
                }
            }
        },
        "Flow": {
            "Cardinality": {
                "DstIpsOut": 0,
                "DstPortsOut": 0,
                "SrcIpsIn": 0,
                "SrcPortsIn": 0
            },
            "DeepSamples": 0,
            "EventRate": {
                "Live": 0,
                "P50": 0,
                "P90": 0,
                "P95": 0,
                "P99": 0
            },
            "Filtered": 0,
            "Flows": 0,
            "Ipv4": 0,
            "Ipv6": 0,
            "OtherL4": 0,
            "PayloadSize": {
                "P50": 0,
                "P90": 0,
                "P95": 0,
                "P99": 0
            },
            "Period": {
                "Length": 0,
                "StartTS": 0
            },
            "Rates": {
                "Bps": {
                    "Live": 0,
                    "P50": 0,
                    "P90": 0,
                    "P95": 0,
                    "P99": 0
                },
                "Pps": {
                    "Live": 0,
                    "P50": 0,
                    "P90": 0,
                    "P95": 0,
                    "P99": 0
                }
            },
            "TCP": 0,
            "TopDstIpsAndPortBytes": [],
            "TopDstIpsAndPortPackets": [],
            "TopDstIpsBytes": [],
            "TopDstIpsPackets": [],
            "TopDstPortsBytes": [],
            "TopDstPortsPackets": [],
            "TopInIfIndexBytes": [],
            "TopInIfIndexPackets": [],
            "TopOutIfIndexBytes": [],
            "TopOutIfIndexPackets": [],
            "TopSrcIpsAndPortBytes": [],
            "TopSrcIpsAndPortPackets": [],
            "TopSrcIpsBytes": [],
            "TopSrcIpsPackets": [],
            "TopSrcPortsBytes": [],
            "TopSrcPortsPackets": [],
            "Total": 0,
            "Udp": 0
        },
        "Packets": {
            "Cardinality": {
                "DstIpsOut": 1,
                "SrcIpsIn": 1
            },
            "DeepSamples": 270,
            "In": 135,
            "Ipv4": 0,
            "Ipv6": 270,
            "OtherL4": 0,
            "Out": 135,
            "Period": {
                "Length": 62,
                "StartTS": 1656691477
            },
            "Rates": {
                "Pps_in": {
                    "Live": 0,
                    "P50": 0,
                    "P90": 5,
                    "P95": 7,
                    "P99": 29
                },
                "Pps_out": {
                    "Live": 0,
                    "P50": 0,
                    "P90": 6,
                    "P95": 7,
                    "P99": 25
                },
                "Pps_total": {
                    "Live": 0,
                    "P50": 0,
                    "P90": 11,
                    "P95": 14,
                    "P99": 54
                }
            },
            "TCP": 0,
            "TopASN": [],
            "TopGeoLoc": [],
            "TopIpv4": [],
            "TopIpv6": [
                {
                    "Estimate": 270,
                    "Name": "2804:14d:1:0:181:213:132:3"
                }
            ],
            "Total": 270,
            "UDP": 270
        },
        "Pcap": {
            "IfDrops": 0,
            "OsDrops": 0,
            "TcpReassemblyErrors": 0
        }
    }
}
```