### PR TITLE
Added readiness for pktvisor backend

### DIFF
--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -301,7 +301,7 @@ func (p *pktvisorBackend) Start() error {
 	}
 
 	if readinessError != nil {
-		p.logger.Error("pktvisor error on readiness", zap.Error(err))
+		p.logger.Error("pktvisor error on readiness", zap.Error(readinessError))
 		err = p.proc.Stop()
 		if err != nil {
 			p.logger.Error("proc.Stop error", zap.Error(err))

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -10,7 +10,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/eclipse/paho.mqtt.golang"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os/exec"
+	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/go-cmd/cmd"
 	"github.com/go-co-op/gocron"
 	"github.com/ns1labs/orb/agent/backend"
@@ -21,11 +27,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"os/exec"
-	"time"
 )
 
 var _ backend.Backend = (*pktvisorBackend)(nil)
@@ -301,6 +302,10 @@ func (p *pktvisorBackend) Start() error {
 
 	if readinessError != nil {
 		p.logger.Error("pktvisor error on readiness", zap.Error(err))
+		err = p.proc.Stop()
+		if err != nil {
+			p.logger.Error("proc.Stop error", zap.Error(err))
+		}
 		return readinessError
 	}
 

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -296,7 +296,7 @@ func (p *pktvisorBackend) Start() error {
 			p.logger.Info(fmt.Sprintf("pktvisor readiness ok, got version %s", appMetrics.App.Version))
 			break
 		}
-		p.logger.Info(fmt.Sprintf("pktvisor is not ready, trying again in %d seconds", ReadinessTimeout))
+		p.logger.Info("pktvisor is not ready, trying again")
 	}
 
 	if readinessError != nil {


### PR DESCRIPTION
Created a simple verification when starting up the pktvisor backend to await for it to be ready before starting the orb client.

fixes #1419