### PR TITLE
fix(orb-ui): #1406 - Align add handler button to the left

### DIFF
--- a/ui/src/app/pages/datasets/policies.agent/add/agent.policy.add.component.scss
+++ b/ui/src/app/pages/datasets/policies.agent/add/agent.policy.add.component.scss
@@ -177,6 +177,6 @@ mat-chip nb-icon {
 }
 
 .add-handler-button {
-  align-self: center;
   margin-top: 1rem;
+  margin: 10px 0;
 }


### PR DESCRIPTION
issue #1406

![image](https://user-images.githubusercontent.com/101733592/177403256-448d5760-55cb-4c81-9c96-e1e7541b8cbc.png)
