### PR TITLE
fix(orb-ui): #1106 - Fix add components sizes

### DIFF
--- a/ui/src/app/pages/fleet/agents/add/agent.add.component.html
+++ b/ui/src/app/pages/fleet/agents/add/agent.add.component.html
@@ -68,14 +68,14 @@
               <p>{{strings.add.step.desc2}}</p>
             </div>
           </ng-template>
-          <div class="d-flex flex-wrap col-8">
+          <div class="d-flex flex-wrap">
             <p *ngIf="(selectedTags | json) === '{}'">Agent tags are optional and may be set here or when you are
               provisioning an Agent.<br> The lack of tags will block an Agent to be matched during the Agent Group
               creation.</p>
             <ngx-tag-control [(tags)]="selectedTags" autofocus></ngx-tag-control>
             <hr>
           </div>
-          <div class="d-flex justify-content-end col-8">
+          <div class="d-flex justify-content-end">
             <button class="next-button"
                     data-orb-qa-id="button#next"
                     nbButton

--- a/ui/src/app/pages/fleet/agents/add/agent.add.component.scss
+++ b/ui/src/app/pages/fleet/agents/add/agent.add.component.scss
@@ -80,7 +80,7 @@ nb-card-footer {
 
 
   .step-content {
-    min-width: 500px !important;
+    width: 500px;
   }
 
   .connector {

--- a/ui/src/app/pages/fleet/groups/add/agent.group.add.component.html
+++ b/ui/src/app/pages/fleet/groups/add/agent.group.add.component.html
@@ -81,7 +81,7 @@
               <p>{{strings.add.step.desc2}}</p>
             </div>
           </ng-template>
-          <div class="d-flex row flex-column col-8">
+          <div class="d-flex row flex-column">
             <ngx-tag-control
               (tagsChange)="updateMatches()"
               [(tags)]="selectedTags"></ngx-tag-control>

--- a/ui/src/app/pages/fleet/groups/add/agent.group.add.component.scss
+++ b/ui/src/app/pages/fleet/groups/add/agent.group.add.component.scss
@@ -92,7 +92,7 @@ mat-chip nb-icon {
 
 
   .step-content {
-    min-width: 500px !important;
+    width: 500px;
   }
 
   .connector {


### PR DESCRIPTION
issue #1407

There were some col-8 properties that seemed to reduce the size of the elements with no need, only to make the component readable on small device. However, changing the min-width property to be only width should solve this problem and we have the following behavior:

https://user-images.githubusercontent.com/101733592/177414396-365dc20c-d8d9-439d-8335-594b65338965.mp4


