### PR TITLE
fix(fleet): remove dataset from policy manager when deleting group, but not removing the policy

### DIFF
--- a/agent/rpc_from.go
+++ b/agent/rpc_from.go
@@ -147,6 +147,10 @@ func (a *orbAgent) handleAgentGroupRemoval(rpc fleet.GroupRemovedRPCPayload) {
 				a.logger.Warn("failed to remove a policy, ignoring", zap.String("policy_id", policy.ID), zap.String("policy_name", policy.Name), zap.Error(err))
 				continue
 			}
+		} else {
+			for _, datasetID := range rpc.DatasetsID {
+				a.removeDatasetFromPolicy(datasetID, policy.ID)
+			}
 		}
 	}
 }

--- a/fleet/comms_rpc.go
+++ b/fleet/comms_rpc.go
@@ -62,8 +62,9 @@ type GroupRemovedRPC struct {
 }
 
 type GroupRemovedRPCPayload struct {
-	AgentGroupID string `json:"agent_group_id"`
-	ChannelID    string `json:"channel_id"`
+	AgentGroupID string   `json:"agent_group_id"`
+	ChannelID    string   `json:"channel_id"`
+	DatasetsID   []string `json:"datasets_id"`
 }
 
 const DatasetRemovedRPCFunc = "dataset_removed"


### PR DESCRIPTION
In the case of multiples groups applying the same policy and removing one of them also removes its dataset on the agent's heartbeat
![image](https://user-images.githubusercontent.com/86990690/177829996-f681abb7-5282-4d18-b687-16b05d383fb8.png)
![image](https://user-images.githubusercontent.com/86990690/177830189-73b3acc8-99de-4dd7-a034-3fafaaad656e.png)
