### PR TITLE
fix(orb-ui): #1018 - Improve policy error msgs

### DIFF
--- a/policies/api/http/endpoint.go
+++ b/policies/api/http/endpoint.go
@@ -10,6 +10,7 @@ package http
 
 import (
 	"context"
+	"fmt"
 	"github.com/go-kit/kit/endpoint"
 	"github.com/ns1labs/orb/pkg/errors"
 	"github.com/ns1labs/orb/pkg/types"
@@ -41,6 +42,9 @@ func addPolicyEndpoint(svc policies.Service) endpoint.Endpoint {
 
 		saved, err := svc.AddPolicy(ctx, req.token, policy)
 		if err != nil {
+			if e, ok := err.(errors.Error); ok && errors.Contains(err, policies.ErrValidatePolicy) {
+				err = errors.New(fmt.Sprintf("%s : %s", e.Msg(), e.Err()))
+			}
 			return nil, err
 		}
 

--- a/ui/src/app/common/services/agents/agent.policies.service.ts
+++ b/ui/src/app/common/services/agents/agent.policies.service.ts
@@ -63,7 +63,7 @@ export class AgentPoliciesService {
         err => {
           this.notificationsService.error('Failed to create Agent Policy',
             `Error: ${ err.status } - ${ err.statusText } - ${ err.error.error }`);
-          return of(err);
+          return Observable.throwError(err);
         },
       );
   }
@@ -104,8 +104,8 @@ export class AgentPoliciesService {
       .catch(
         err => {
           this.notificationsService.error('Failed to edit Agent Policy',
-            `Error: ${ err.status } - ${ err.statusText }`);
-          return of(err);
+            `Error: ${ err.status } - ${ err.statusText } - ${ err.error.error }`);
+          return Observable.throwError(err);
         },
       );
   }

--- a/ui/src/app/pages/datasets/policies.agent/view/agent.policy.view.component.ts
+++ b/ui/src/app/pages/datasets/policies.agent/view/agent.policy.view.component.ts
@@ -100,9 +100,14 @@ export class AgentPolicyViewComponent implements OnInit, OnDestroy {
         policy_data: policyInterface,
       };
     } else {
-      interfacePartial = {
-        policy: JSON.parse(policyInterface) as PolicyConfig,
-      };
+      try {
+        interfacePartial = {
+          policy: JSON.parse(policyInterface) as PolicyConfig,
+        };
+      } catch (err) {
+        this.notifications.error('Failed to edit Agent Policy', `Error: Invalid JSON`);
+        return
+      }
     }
 
     const payload = {


### PR DESCRIPTION
issue #1018

Besides the issue with the yaml error message when trying to create the policy, the page was going to the next step even with errors:

https://user-images.githubusercontent.com/101733592/177845417-bb3bdf71-50fb-4cbc-864c-4d6462cb9dfb.mp4

After fix, a more detailed error message is shown, and we stay at the current step:

![image](https://user-images.githubusercontent.com/101733592/177844247-c641f906-35df-4a0c-8da1-f52f0de4e2a8.png)

The error messages shown when trying to edit the policies where also improved. The error with JSON was not even verified before:

![image](https://user-images.githubusercontent.com/101733592/177839942-3855cf1d-8435-476b-8f5b-f2869ebeb22e.png)

![image](https://user-images.githubusercontent.com/101733592/177845155-4f22fe8a-c7ef-4a81-8076-835a7a05460f.png)