### PR TITLE
feat(agent): successfully on lost connection restore all subs and policies.

### DIFF
--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -344,7 +344,7 @@ func (p *pktvisorBackend) scrapeDefault() error {
 		for pName, pMetrics := range metrics {
 			data, err := p.policyRepo.GetByName(pName)
 			if err != nil {
-				p.logger.Warn("skipping pktvisor policy not managed by orb", zap.String("policy", pName), zap.Error(err))
+				p.logger.Warn("skipping pktvisor policy not managed by orb", zap.String("policy", pName), zap.String("error message", err.Error()))
 				continue
 			}
 			payloadData, err := json.Marshal(pMetrics)

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -121,7 +121,6 @@ func (a *orbAgent) startComms(config config.MQTTConfig) error {
 			return ErrMqttConnection
 		}
 	}
-	a.requestReconnection(a.client, config)
 
 	return nil
 }

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -30,6 +30,10 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 			a.Stop()
 		}
 	})
+	opts.SetResumeSubs(true)
+	opts.SetOnConnectHandler(func(client mqtt.Client) {
+		a.requestReconnection(client, config)
+	})
 	opts.SetPingTimeout(5 * time.Second)
 	opts.SetAutoReconnect(true)
 


### PR DESCRIPTION
Integration Test report running against Staging

Logs of the reconnection attempts while offline

```logs
2022-07-08T15:13:55.746Z	ERROR	agent/logging.go:43	CRITICAL mqtt log	{"payload": ["[pinger]  ","pingresp not received, disconnecting"]}
github.com/ns1labs/orb/agent.(*agentLoggerCritical).Println
	/go/src/github.com/ns1labs/orb/agent/logging.go:43
github.com/eclipse/paho%2emqtt%2egolang.keepalive
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/ping.go:72
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","internalConnLost called"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","stopCommsWorkers called"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","incoming complete"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","startIncomingComms: ibound complete"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","startIncomingComms goroutine complete"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","stopCommsWorkers waiting for workers"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","outgoing waiting for an outbound message"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","internalConnLost waiting on workers"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[router]  ","matchAndDispatch exiting"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","startCommsWorkers output redirector finished"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","stopCommsWorkers waiting for comms"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","outgoing waiting for an outbound message"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","outgoing waiting for an outbound message"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","outgoing comms stopping"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","startComms closing outError"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","incoming comms goroutine done"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","stopCommsWorkers done"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","internalConnLost workers stopped"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","internalConnLost complete"]}
2022-07-08T15:13:55.746Z	ERROR	agent/comms.go:27	error on connection lost, retrying to reconnect	{"error": "pingresp not received, disconnecting"}
github.com/ns1labs/orb/agent.(*orbAgent).connect.func2
	/go/src/github.com/ns1labs/orb/agent/comms.go:27
2022-07-08T15:13:55.746Z	INFO	cloud_config/cloud_config.go:173	using explicitly specified cloud configuration	{"address": "tls://orb.live:8883", "id": "f44eec80-3748-437f-ab6b-8767ed9aaa4c"}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","enter reconnect"]}
2022-07-08T15:13:55.746Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","about to write new connect msg"]}
2022-07-08T15:14:00.747Z	ERROR	agent/logging.go:49	ERROR mqtt log	{"payload": ["[client]  ","dial tcp: lookup orb.live: Try again"]}
github.com/ns1labs/orb/agent.(*agentLoggerError).Println
	/go/src/github.com/ns1labs/orb/agent/logging.go:49
github.com/eclipse/paho%2emqtt%2egolang.(*client).attemptConnection
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:407
github.com/eclipse/paho%2emqtt%2egolang.(*client).reconnect
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:331
2022-07-08T15:14:00.747Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","Reconnect failed, sleeping for",1,"seconds:",{}]}
2022-07-08T15:14:01.747Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","about to write new connect msg"]}
2022-07-08T15:14:06.751Z	ERROR	agent/logging.go:49	ERROR mqtt log	{"payload": ["[client]  ","dial tcp: lookup orb.live: Try again"]}
github.com/ns1labs/orb/agent.(*agentLoggerError).Println
	/go/src/github.com/ns1labs/orb/agent/logging.go:49
github.com/eclipse/paho%2emqtt%2egolang.(*client).attemptConnection
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:407
github.com/eclipse/paho%2emqtt%2egolang.(*client).reconnect
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:331
2022-07-08T15:14:06.751Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","Reconnect failed, sleeping for",2,"seconds:",{}]}
2022-07-08T15:14:08.752Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","about to write new connect msg"]}
2022-07-08T15:14:13.755Z	ERROR	agent/logging.go:49	ERROR mqtt log	{"payload": ["[client]  ","dial tcp: lookup orb.live: Try again"]}
github.com/ns1labs/orb/agent.(*agentLoggerError).Println
	/go/src/github.com/ns1labs/orb/agent/logging.go:49
github.com/eclipse/paho%2emqtt%2egolang.(*client).attemptConnection
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:407
github.com/eclipse/paho%2emqtt%2egolang.(*client).reconnect
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:331
2022-07-08T15:14:13.755Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","Reconnect failed, sleeping for",4,"seconds:",{}]}
2022-07-08T15:14:17.757Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","about to write new connect msg"]}
2022-07-08T15:14:22.760Z	ERROR	agent/logging.go:49	ERROR mqtt log	{"payload": ["[client]  ","dial tcp: lookup orb.live: Try again"]}
github.com/ns1labs/orb/agent.(*agentLoggerError).Println
	/go/src/github.com/ns1labs/orb/agent/logging.go:49
github.com/eclipse/paho%2emqtt%2egolang.(*client).attemptConnection
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:407
github.com/eclipse/paho%2emqtt%2egolang.(*client).reconnect
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:331
2022-07-08T15:14:22.761Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","Reconnect failed, sleeping for",8,"seconds:",{}]}
2022-07-08T15:14:30.761Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","about to write new connect msg"]}
2022-07-08T15:14:35.766Z	ERROR	agent/logging.go:49	ERROR mqtt log	{"payload": ["[client]  ","dial tcp: lookup orb.live: Try again"]}
github.com/ns1labs/orb/agent.(*agentLoggerError).Println
	/go/src/github.com/ns1labs/orb/agent/logging.go:49
github.com/eclipse/paho%2emqtt%2egolang.(*client).attemptConnection
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:407
github.com/eclipse/paho%2emqtt%2egolang.(*client).reconnect
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:331
2022-07-08T15:14:35.766Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","Reconnect failed, sleeping for",16,"seconds:",{}]}
2022-07-08T15:14:51.766Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","about to write new connect msg"]}
2022-07-08T15:14:56.770Z	ERROR	agent/logging.go:49	ERROR mqtt log	{"payload": ["[client]  ","dial tcp: lookup orb.live: Try again"]}
github.com/ns1labs/orb/agent.(*agentLoggerError).Println
	/go/src/github.com/ns1labs/orb/agent/logging.go:49
github.com/eclipse/paho%2emqtt%2egolang.(*client).attemptConnection
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:407
github.com/eclipse/paho%2emqtt%2egolang.(*client).reconnect
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:331
2022-07-08T15:14:56.770Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","Reconnect failed, sleeping for",32,"seconds:",{}]}
2022-07-08T15:15:28.774Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","about to write new connect msg"]}
2022-07-08T15:15:33.777Z	ERROR	agent/logging.go:49	ERROR mqtt log	{"payload": ["[client]  ","dial tcp: lookup orb.live: Try again"]}
github.com/ns1labs/orb/agent.(*agentLoggerError).Println
	/go/src/github.com/ns1labs/orb/agent/logging.go:49
github.com/eclipse/paho%2emqtt%2egolang.(*client).attemptConnection
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:407
github.com/eclipse/paho%2emqtt%2egolang.(*client).reconnect
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:331
2022-07-08T15:15:33.777Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","Reconnect failed, sleeping for",64,"seconds:",{}]}
2022-07-08T15:16:37.780Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","about to write new connect msg"]}
2022-07-08T15:16:42.785Z	ERROR	agent/logging.go:49	ERROR mqtt log	{"payload": ["[client]  ","dial tcp: lookup orb.live: Try again"]}
github.com/ns1labs/orb/agent.(*agentLoggerError).Println
	/go/src/github.com/ns1labs/orb/agent/logging.go:49
github.com/eclipse/paho%2emqtt%2egolang.(*client).attemptConnection
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:407
github.com/eclipse/paho%2emqtt%2egolang.(*client).reconnect
	/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.4.1/client.go:331
2022-07-08T15:16:42.785Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","Reconnect failed, sleeping for",128,"seconds:",{}]}
2022-07-08T15:18:50.786Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","about to write new connect msg"]}
2022-07-08T15:18:51.737Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","socket connected to broker"]}
2022-07-08T15:18:51.737Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","Using MQTT 3.1.1 protocol"]}
2022-07-08T15:18:51.737Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","connect started"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","received connack"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","startCommsWorkers called"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","client is connected/reconnected"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","incoming started"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","startIncomingComms started"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","outgoing started"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","startComms started"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","startCommsWorkers done"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[store]   ","enter Resume"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[store]   ","memorystore get: message",95,"found"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[store]   ","loaded pending publish (95)"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","logic waiting for msg on ibound"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[pinger]  ","keepalive starting"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[store]   ",{"Qos":1,"MessageID":95}]}
2022-07-08T15:18:51.936Z	DEBUG	agent/heartbeats.go:24	heartbeat
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[store]   ","memorystore get: message",96,"found"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[store]   ","loaded pending publish (96)"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[store]   ",{"Qos":1,"MessageID":96}]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","enter Subscribe"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","enter Publish"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","SUBSCRIBE: dup: false qos: 1 retain: false rLength: 0 MessageID: 97 topics: [channels/f7ebdbf0-704e-4d68-a113-42777612aee8/messages/fromcore]"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","sending subscribe message, topic:","channels/f7ebdbf0-704e-4d68-a113-42777612aee8/messages/fromcore"]}
2022-07-08T15:18:51.936Z	INFO	pktvisor/pktvisor.go:384	scraped and published metrics	{"topic": "channels/f7ebdbf0-704e-4d68-a113-42777612aee8/messages/be/pktvisor/m/f", "payload_size_b": 8468, "batch_count": 2}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[client]  ","sending publish message, topic:","channels/f7ebdbf0-704e-4d68-a113-42777612aee8/messages/hb"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","outgoing waiting for an outbound message"]}
2022-07-08T15:18:51.936Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","obound msg to write",95]}
2022-07-08T15:18:51.937Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","obound wrote msg, id:",95]}
2022-07-08T15:18:51.937Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[net]     ","outgoing waiting for an outbound message"]}
2022-07-08T15:18:51.937Z	DEBUG	agent/logging.go:37	DEBUG mqtt log	{"payload": ["[store]   ","exit resume"]}
```

Here is the complete log of the agent

[_loving_mendel_logs(5).txt](https://github.com/ns1labs/orb/files/9073226/_loving_mendel_logs.5.txt)



