### PR TITLE
Feat/orb 1119 remove dataset when remove policy

### DIFF
--- a/policies/mocks/policies.go
+++ b/policies/mocks/policies.go
@@ -158,6 +158,16 @@ func (m *mockPoliciesRepository) UpdatePolicy(ctx context.Context, owner string,
 	return policies.ErrNotFound
 }
 
+func (m *mockPoliciesRepository) DeleteAllDatasetsPolicy(ctx context.Context, policyID string, ownerID string) error {
+	for _, dataset := range m.ddb {
+		if dataset.PolicyID == policyID && dataset.MFOwnerID == ownerID {
+			delete(m.ddb, dataset.ID)
+		}
+	}
+
+	return nil
+}
+
 func NewPoliciesRepository() policies.Repository {
 	return &mockPoliciesRepository{
 		pdb: make(map[string]policies.Policy),

--- a/policies/mocks/policies.go
+++ b/policies/mocks/policies.go
@@ -90,7 +90,7 @@ func (m *mockPoliciesRepository) DeleteSinkFromAllDatasets(ctx context.Context, 
 
 func (m *mockPoliciesRepository) DeleteDataset(ctx context.Context, ownerID string, dsID string) error {
 	if _, ok := m.ddb[dsID]; ok {
-		if m.ddb[dsID].MFOwnerID != ownerID {
+		if m.ddb[dsID].MFOwnerID == ownerID {
 			delete(m.ddb, dsID)
 		}
 	}

--- a/policies/policies.go
+++ b/policies/policies.go
@@ -176,4 +176,7 @@ type Repository interface {
 
 	// DeleteAgentGroupFromAllDatasets removes agent group from a dataset
 	DeleteAgentGroupFromAllDatasets(ctx context.Context, groupID string, ownerID string) error
+
+	// DeleteAllDatasetsPolicy removes all datasets by policyID
+	DeleteAllDatasetsPolicy(ctx context.Context, policyID string, ownerID string) error
 }

--- a/policies/policy_service.go
+++ b/policies/policy_service.go
@@ -185,16 +185,9 @@ func (s policiesService) RemovePolicy(ctx context.Context, token string, policyI
 		return err
 	}
 
-	datasets, err := s.repo.RetrieveDatasetsByPolicyID(ctx, policyID, ownerID)
+	err = s.repo.DeleteAllDatasetsPolicy(ctx, policyID, ownerID)
 	if err != nil {
 		return err
-	}
-
-	for _, dataset := range datasets {
-		err := s.repo.DeleteDataset(ctx, ownerID, dataset.ID)
-		if err != nil {
-			return err
-		}
 	}
 
 	err = s.repo.DeletePolicy(ctx, ownerID, policyID)

--- a/policies/policy_service.go
+++ b/policies/policy_service.go
@@ -184,12 +184,20 @@ func (s policiesService) RemovePolicy(ctx context.Context, token string, policyI
 	if err != nil {
 		return err
 	}
-	err = s.repo.DeletePolicy(ctx, ownerID, policyID)
+
+	datasets, err := s.repo.RetrieveDatasetsByPolicyID(ctx, policyID, ownerID)
 	if err != nil {
 		return err
 	}
 
-	err = s.repo.InactivateDatasetByPolicyID(ctx, policyID, ownerID)
+	for _, dataset := range datasets {
+		err := s.repo.DeleteDataset(ctx, ownerID, dataset.ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = s.repo.DeletePolicy(ctx, ownerID, policyID)
 	if err != nil {
 		return err
 	}

--- a/policies/policy_service_test.go
+++ b/policies/policy_service_test.go
@@ -278,25 +278,31 @@ func TestRemovePolicy(t *testing.T) {
 
 	plcy := createPolicy(t, svc, "policy")
 
+	dataset := createDataset(t, svc, "dataset")
+
 	cases := map[string]struct {
-		id    string
-		token string
-		err   error
+		id        string
+		token     string
+		datasetID string
+		err       error
 	}{
 		"Remove a existing policy": {
-			id:    plcy.ID,
-			token: token,
-			err:   nil,
+			id:        dataset.PolicyID,
+			token:     token,
+			datasetID: dataset.ID,
+			err:       nil,
 		},
 		"delete non-existent policy": {
-			id:    wrongID,
-			token: token,
-			err:   nil,
+			id:        wrongID,
+			token:     token,
+			datasetID: wrongID,
+			err:       nil,
 		},
 		"delete policy with wrong credentials": {
-			id:    plcy.ID,
-			token: invalidToken,
-			err:   policies.ErrUnauthorizedAccess,
+			id:        plcy.ID,
+			token:     invalidToken,
+			datasetID: wrongID,
+			err:       policies.ErrUnauthorizedAccess,
 		},
 	}
 
@@ -304,6 +310,9 @@ func TestRemovePolicy(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 			err := svc.RemovePolicy(context.Background(), tc.token, tc.id)
 			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s", desc, tc.err, err))
+
+			_, err = svc.ViewDatasetByID(context.Background(), token, tc.datasetID)
+			assert.True(t, errors.Contains(policies.ErrNotFound, err), fmt.Sprintf("%s: expected %s got %s", desc, policies.ErrNotFound, err))
 		})
 	}
 }

--- a/policies/postgres/datasets_test.go
+++ b/policies/postgres/datasets_test.go
@@ -1017,9 +1017,6 @@ func TestDeleteAllDatasetsPolicy(t *testing.T) {
 	oID, err := uuid.NewV4()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-	//oID2, err := uuid.NewV4()
-	//require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-
 	policyWithNoDataset, err := uuid.NewV4()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
@@ -1039,9 +1036,6 @@ func TestDeleteAllDatasetsPolicy(t *testing.T) {
 	nameID, err := types.NewIdentifier("mydataset")
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-	//nameID2, err := types.NewIdentifier("mydataset2")
-	//require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-
 	dataset := policies.Dataset{
 		Name:         nameID,
 		MFOwnerID:    oID.String(),
@@ -1053,19 +1047,10 @@ func TestDeleteAllDatasetsPolicy(t *testing.T) {
 		Created:      time.Time{},
 	}
 
-	//dataset2 := dataset
-	//dataset2.Name = nameID2
-	//dataset2.MFOwnerID = oID2.String()
-
 	dsID, err := repo.SaveDataset(context.Background(), dataset)
 	require.Nil(t, err, fmt.Sprintf("Unexpected error: %s", err))
 
 	dataset.ID = dsID
-
-	//dsID2, err := repo.SaveDataset(context.Background(), dataset2)
-	//require.Nil(t, err, fmt.Sprintf("Unexpected error: %s", err))
-
-	//dataset2.ID = dsID2
 
 	cases := map[string]struct {
 		policyID       string

--- a/policies/postgres/datasets_test.go
+++ b/policies/postgres/datasets_test.go
@@ -1010,6 +1010,99 @@ func TestDeleteAgentGroupFromDataset(t *testing.T) {
 	}
 }
 
+func TestDeleteAllDatasetsPolicy(t *testing.T) {
+	dbMiddleware := postgres.NewDatabase(db)
+	repo := postgres.NewPoliciesRepository(dbMiddleware, logger)
+
+	oID, err := uuid.NewV4()
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+
+	//oID2, err := uuid.NewV4()
+	//require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+
+	policyWithNoDataset, err := uuid.NewV4()
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+
+	groupID, err := uuid.NewV4()
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+
+	policyID, err := uuid.NewV4()
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+
+	sinkIDs := make([]string, 2)
+	for i := 0; i < 2; i++ {
+		sinkID, err := uuid.NewV4()
+		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+		sinkIDs[i] = sinkID.String()
+	}
+
+	nameID, err := types.NewIdentifier("mydataset")
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+
+	//nameID2, err := types.NewIdentifier("mydataset2")
+	//require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+
+	dataset := policies.Dataset{
+		Name:         nameID,
+		MFOwnerID:    oID.String(),
+		Valid:        true,
+		AgentGroupID: groupID.String(),
+		PolicyID:     policyID.String(),
+		SinkIDs:      sinkIDs,
+		Metadata:     types.Metadata{"testkey": "testvalue"},
+		Created:      time.Time{},
+	}
+
+	//dataset2 := dataset
+	//dataset2.Name = nameID2
+	//dataset2.MFOwnerID = oID2.String()
+
+	dsID, err := repo.SaveDataset(context.Background(), dataset)
+	require.Nil(t, err, fmt.Sprintf("Unexpected error: %s", err))
+
+	dataset.ID = dsID
+
+	//dsID2, err := repo.SaveDataset(context.Background(), dataset2)
+	//require.Nil(t, err, fmt.Sprintf("Unexpected error: %s", err))
+
+	//dataset2.ID = dsID2
+
+	cases := map[string]struct {
+		policyID       string
+		datasetID      string
+		owner          string
+		deleteDatasets bool
+		err            error
+	}{
+		"delete existing policy with existing datasets": {
+			policyID:       policyID.String(),
+			datasetID:      dataset.ID,
+			owner:          oID.String(),
+			deleteDatasets: true,
+			err:            nil,
+		},
+		"delete existing policy with no existing datasets": {
+			policyID:       policyWithNoDataset.String(),
+			datasetID:      dataset.ID,
+			owner:          oID.String(),
+			deleteDatasets: false,
+			err:            nil,
+		},
+	}
+
+	for desc, tc := range cases {
+		t.Run(desc, func(t *testing.T) {
+			err := repo.DeleteAllDatasetsPolicy(context.Background(), tc.policyID, tc.owner)
+			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected '%s' got '%s'", desc, tc.err, err))
+
+			if tc.deleteDatasets {
+				_, err = repo.RetrieveDatasetByID(context.Background(), tc.datasetID, tc.owner)
+				assert.True(t, errors.Contains(err, errors.ErrNotFound), fmt.Sprintf("%s: expected '%s' got '%s'", desc, errors.ErrNotFound, err))
+			}
+		})
+	}
+}
+
 func testSortDataset(t *testing.T, pm policies.PageMetadata, ags []policies.Dataset) {
 	t.Helper()
 	switch pm.Order {

--- a/policies/postgres/policies.go
+++ b/policies/postgres/policies.go
@@ -645,7 +645,7 @@ func (r policiesRepository) DeleteAllDatasetsPolicy(ctx context.Context, policyI
 				return errors.Wrap(policies.ErrMalformedEntity, err)
 			}
 		}
-		return errors.Wrap(fleet.ErrUpdateEntity, err)
+		return errors.Wrap(fleet.ErrRemoveEntity, err)
 	}
 
 	_, err = res.RowsAffected()


### PR DESCRIPTION
 Remove all datasets that are linked with a policy when removing the policy

![Screenshot from 2022-07-08 15-51-01](https://user-images.githubusercontent.com/86990690/178055629-d05288f7-b433-4b92-aeaf-aabc630d8325.png)
After removing the policy:
![Screenshot from 2022-07-08 15-51-36](https://user-images.githubusercontent.com/86990690/178055642-a120b999-6d49-4153-b5e4-302352478e72.png)

