### PR TITLE
Allow multiple sink tags to be displayed

### DIFF
--- a/ui/src/app/pages/sinks/list/sink.list.component.html
+++ b/ui/src/app/pages/sinks/list/sink.list.component.html
@@ -85,7 +85,7 @@
   <div class="d-block">
     <mat-chip-list nbTooltip="{{ value | json }}">
       <mat-chip
-        *ngFor="let tag of value | keyvalue | slice:0:3"
+        *ngFor="let tag of value | keyvalue; index as i;"
         [style.background-color]="tag | tagcolor"
         class="orb-tag-chip ">
         {{tag | tagchip}}


### PR DESCRIPTION
### Description
**Issue:** #1464 
Only three tags are being displayed in Sink Management list, even if more are created.

### Before
![image](https://user-images.githubusercontent.com/42921279/178795250-75bc1c54-5b08-4fbd-8d31-9cd9a36e15b6.png)

### After
![image](https://user-images.githubusercontent.com/42921279/178795430-76d042a0-a0e8-4b3e-baf2-41379a942b04.png)
