### PR TITLE
feat(agent): remove restart comms indefinetely

### DIFF
--- a/agent/comms.go
+++ b/agent/comms.go
@@ -14,8 +14,6 @@ import (
 	"time"
 )
 
-var disconnectAttempts = 0
-
 func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 
 	opts := mqtt.NewClientOptions().AddBroker(config.Address).SetClientID(config.Id)
@@ -26,7 +24,7 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 		a.logger.Info("message on unknown channel, ignoring", zap.String("topic", message.Topic()), zap.ByteString("payload", message.Payload()))
 	})
 	opts.SetConnectionLostHandler(func(client mqtt.Client, err error) {
-		a.logger.Error("connection to mqtt lost", zap.Int("#attempt", disconnectAttempts), zap.Error(err))
+		a.logger.Error("connection to mqtt lost", zap.Error(err))
 	})
 	opts.SetPingTimeout(5 * time.Second)
 	opts.SetAutoReconnect(false)

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -67,7 +67,8 @@ func (a *orbAgent) requestReconnection(client mqtt.Client, config config.MQTTCon
 	}
 
 	if token := client.Subscribe(a.rpcFromCoreTopic, 1, a.handleRPCFromCore); token.Wait() && token.Error() != nil {
-		a.logger.Error("failed to subscribe to RPC topic", zap.String("topic", a.rpcFromCoreTopic), zap.Error(token.Error()))
+		a.logger.Fatal("failed to subscribe to RPC topic", zap.String("topic", a.rpcFromCoreTopic), zap.Error(token.Error()))
+		a.Stop()
 	}
 
 	err := a.sendCapabilities()

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -25,10 +25,6 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 	})
 	opts.SetConnectionLostHandler(func(client mqtt.Client, err error) {
 		a.logger.Error("error on connection lost, retrying to reconnect", zap.Error(err))
-		if err = a.restartComms(); err != nil {
-			a.logger.Error("got error trying to reconnect, stopping agent", zap.Error(err))
-			a.Stop()
-		}
 	})
 	opts.SetPingTimeout(5 * time.Second)
 	opts.SetAutoReconnect(true)

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -24,7 +24,7 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 		a.logger.Info("message on unknown channel, ignoring", zap.String("topic", message.Topic()), zap.ByteString("payload", message.Payload()))
 	})
 	opts.SetConnectionLostHandler(func(client mqtt.Client, err error) {
-		a.logger.Error("error on connection lost, retrying to reconnect", zap.Error(err))
+		a.logger.Error("connection to mqtt lost", zap.Error(err))
 	})
 	opts.SetPingTimeout(5 * time.Second)
 	opts.SetAutoReconnect(true)

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -40,6 +40,7 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 	opts.SetPingTimeout(5 * time.Second)
 	opts.SetAutoReconnect(false)
 	opts.SetCleanSession(true)
+	opts.SetConnectTimeout(5 * time.Minute)
 	opts.SetResumeSubs(true)
 	opts.SetOnConnectHandler(func(client mqtt.Client) {
 		if client.IsConnected() {

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -25,7 +25,7 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 	})
 	opts.SetConnectionLostHandler(func(client mqtt.Client, err error) {
 		a.logger.Error("connection to mqtt lost", zap.Error(err))
-		a.logger.Info("logging all topics", zap.String("rpcToCoreTopic", a.rpcToCoreTopic),
+		a.logger.Debug("logging all topics", zap.String("rpcToCoreTopic", a.rpcToCoreTopic),
 			zap.String("rpcFromCoreTopic", a.rpcFromCoreTopic),
 			zap.String("capabilitiesTopic", a.capabilitiesTopic),
 			zap.String("heartbeatsTopic", a.heartbeatsTopic),
@@ -35,7 +35,7 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 	opts.SetAutoReconnect(true)
 	opts.SetResumeSubs(false)
 	opts.SetReconnectingHandler(func(client mqtt.Client, options *mqtt.ClientOptions) {
-		a.logger.Info("logging all topics", zap.String("rpcToCoreTopic", a.rpcToCoreTopic),
+		a.logger.Debug("logging all topics", zap.String("rpcToCoreTopic", a.rpcToCoreTopic),
 			zap.String("rpcFromCoreTopic", a.rpcFromCoreTopic),
 			zap.String("capabilitiesTopic", a.capabilitiesTopic),
 			zap.String("heartbeatsTopic", a.heartbeatsTopic),

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -69,6 +69,7 @@ func (a *orbAgent) requestReconnection(client mqtt.Client, config config.MQTTCon
 	if token := client.Subscribe(a.rpcFromCoreTopic, 1, a.handleRPCFromCore); token.Wait() && token.Error() != nil {
 		a.logger.Error("failed to subscribe to agent control plane RPC topic", zap.String("topic", a.rpcFromCoreTopic), zap.Error(token.Error()))
 		a.Stop()
+		a.logger.Fatal("critical failure: unable to subscribe to control plane")
 	}
 
 	err := a.sendCapabilities()

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -25,12 +25,18 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 	})
 	opts.SetConnectionLostHandler(func(client mqtt.Client, err error) {
 		a.logger.Error("connection to mqtt lost", zap.Error(err))
+		a.logger.Debug("logging all topics", zap.String("rpcToCoreTopic", a.rpcToCoreTopic),
+			zap.String("rpcFromCoreTopic", a.rpcFromCoreTopic),
+			zap.String("capabilitiesTopic", a.capabilitiesTopic),
+			zap.String("heartbeatsTopic", a.heartbeatsTopic),
+			zap.String("logTopic", a.logTopic))
 	})
 	opts.SetPingTimeout(5 * time.Second)
 	opts.SetAutoReconnect(true)
 	opts.SetResumeSubs(true)
 	opts.SetOnConnectHandler(func(client mqtt.Client) {
 		a.requestReconnection(client, config)
+
 	})
 
 	if !a.config.OrbAgent.TLS.Verify {

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -67,7 +67,7 @@ func (a *orbAgent) requestReconnection(client mqtt.Client, config config.MQTTCon
 	}
 
 	if token := client.Subscribe(a.rpcFromCoreTopic, 1, a.handleRPCFromCore); token.Wait() && token.Error() != nil {
-		a.logger.Error("failed to subscribe to RPC topic", zap.String("topic", a.rpcFromCoreTopic), zap.Error(token.Error()))
+		a.logger.Error("failed to subscribe to agent control plane RPC topic", zap.String("topic", a.rpcFromCoreTopic), zap.Error(token.Error()))
 		a.Stop()
 	}
 

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -68,7 +68,6 @@ func (a *orbAgent) requestReconnection(client mqtt.Client, config config.MQTTCon
 
 	if token := client.Subscribe(a.rpcFromCoreTopic, 1, a.handleRPCFromCore); token.Wait() && token.Error() != nil {
 		a.logger.Fatal("failed to subscribe to RPC topic", zap.String("topic", a.rpcFromCoreTopic), zap.Error(token.Error()))
-		a.Stop()
 	}
 
 	err := a.sendCapabilities()

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -67,7 +67,8 @@ func (a *orbAgent) requestReconnection(client mqtt.Client, config config.MQTTCon
 	}
 
 	if token := client.Subscribe(a.rpcFromCoreTopic, 1, a.handleRPCFromCore); token.Wait() && token.Error() != nil {
-		a.logger.Fatal("failed to subscribe to RPC topic", zap.String("topic", a.rpcFromCoreTopic), zap.Error(token.Error()))
+		a.logger.Error("failed to subscribe to RPC topic", zap.String("topic", a.rpcFromCoreTopic), zap.Error(token.Error()))
+		a.Stop()
 	}
 
 	err := a.sendCapabilities()

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -40,7 +40,6 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 	opts.SetPingTimeout(5 * time.Second)
 	opts.SetAutoReconnect(false)
 	opts.SetCleanSession(true)
-	opts.SetConnectTimeout(0)
 	opts.SetResumeSubs(true)
 	opts.SetOnConnectHandler(func(client mqtt.Client) {
 		if client.IsConnected() {

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -25,7 +25,7 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 	})
 	opts.SetConnectionLostHandler(func(client mqtt.Client, err error) {
 		a.logger.Error("connection to mqtt lost", zap.Error(err))
-		a.logger.Debug("logging all topics", zap.String("rpcToCoreTopic", a.rpcToCoreTopic),
+		a.logger.Info("logging all topics", zap.String("rpcToCoreTopic", a.rpcToCoreTopic),
 			zap.String("rpcFromCoreTopic", a.rpcFromCoreTopic),
 			zap.String("capabilitiesTopic", a.capabilitiesTopic),
 			zap.String("heartbeatsTopic", a.heartbeatsTopic),
@@ -33,10 +33,21 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 	})
 	opts.SetPingTimeout(5 * time.Second)
 	opts.SetAutoReconnect(true)
-	opts.SetResumeSubs(true)
+	opts.SetResumeSubs(false)
+	opts.SetReconnectingHandler(func(client mqtt.Client, options *mqtt.ClientOptions) {
+		a.logger.Info("logging all topics", zap.String("rpcToCoreTopic", a.rpcToCoreTopic),
+			zap.String("rpcFromCoreTopic", a.rpcFromCoreTopic),
+			zap.String("capabilitiesTopic", a.capabilitiesTopic),
+			zap.String("heartbeatsTopic", a.heartbeatsTopic),
+			zap.String("logTopic", a.logTopic))
+	})
 	opts.SetOnConnectHandler(func(client mqtt.Client) {
 		a.requestReconnection(client, config)
-
+		a.logger.Debug("logging all topics", zap.String("rpcToCoreTopic", a.rpcToCoreTopic),
+			zap.String("rpcFromCoreTopic", a.rpcFromCoreTopic),
+			zap.String("capabilitiesTopic", a.capabilitiesTopic),
+			zap.String("heartbeatsTopic", a.heartbeatsTopic),
+			zap.String("logTopic", a.logTopic))
 	})
 
 	if !a.config.OrbAgent.TLS.Verify {

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -35,8 +35,11 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 			zap.String("heartbeatsTopic", a.heartbeatsTopic),
 			zap.String("logTopic", a.logTopic))
 		time.Sleep(time.Duration(disconnectAttempts) * disconnectBackOffTime)
-		if disconnectAttempts > 13 {
-			_ = a.RestartAll("disconnection")
+		if disconnectAttempts > 13 { // TDB how many attempts
+			if err = a.RestartAll("disconnection"); err != nil {
+				a.logger.Error("stopping agent due to error in restart")
+				a.Stop()
+			}
 		}
 	})
 	opts.SetPingTimeout(5 * time.Second)

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -35,7 +35,7 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 			zap.String("heartbeatsTopic", a.heartbeatsTopic),
 			zap.String("logTopic", a.logTopic))
 		time.Sleep(time.Duration(disconnectAttempts) * disconnectBackOffTime)
-		if disconnectAttempts > 13 { // TDB how many attempts
+		if disconnectAttempts > 13 { // TBD how many attempts
 			if err = a.RestartAll("disconnection"); err != nil {
 				a.logger.Error("stopping agent due to error in restart")
 				a.Stop()

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -33,7 +33,7 @@ func (a *orbAgent) connect(config config.MQTTConfig) (mqtt.Client, error) {
 	})
 	opts.SetPingTimeout(5 * time.Second)
 	opts.SetAutoReconnect(true)
-	opts.SetResumeSubs(false)
+	opts.SetResumeSubs(true)
 	opts.SetReconnectingHandler(func(client mqtt.Client, options *mqtt.ClientOptions) {
 		a.logger.Debug("logging all topics", zap.String("rpcToCoreTopic", a.rpcToCoreTopic),
 			zap.String("rpcFromCoreTopic", a.rpcFromCoreTopic),

--- a/agent/rpc_from.go
+++ b/agent/rpc_from.go
@@ -75,7 +75,7 @@ func (a *orbAgent) handleAgentPolicies(rpc []fleet.AgentPolicyRPCPayload, fullLi
 func (a *orbAgent) handleGroupRPCFromCore(client mqtt.Client, message mqtt.Message) {
 	go func() {
 		a.logger.Debug("Group RPC message from core", zap.String("topic", message.Topic()), zap.ByteString("payload", message.Payload()))
-
+		disconnectAttempts = 0
 		var rpc fleet.RPC
 		if err := json.Unmarshal(message.Payload(), &rpc); err != nil {
 			a.logger.Error("error decoding RPC message from core", zap.Error(fleet.ErrSchemaMalformed))

--- a/agent/rpc_from.go
+++ b/agent/rpc_from.go
@@ -75,7 +75,6 @@ func (a *orbAgent) handleAgentPolicies(rpc []fleet.AgentPolicyRPCPayload, fullLi
 func (a *orbAgent) handleGroupRPCFromCore(client mqtt.Client, message mqtt.Message) {
 	go func() {
 		a.logger.Debug("Group RPC message from core", zap.String("topic", message.Topic()), zap.ByteString("payload", message.Payload()))
-		disconnectAttempts = 0
 		var rpc fleet.RPC
 		if err := json.Unmarshal(message.Payload(), &rpc); err != nil {
 			a.logger.Error("error decoding RPC message from core", zap.Error(fleet.ErrSchemaMalformed))


### PR DESCRIPTION
A few runs showed that we handled correctly the MQTT EOF failure.
Timeout for connection of 5 minutes.
Shut down the agent if connection doesn't subscribe to control plane.

```
 '{"level":"info","ts":1658178237.4211695,"caller":"cloud_config/cloud_config.go:173","msg":"using explicitly specified cloud configuration","address":"tls://stg.orb.live:8883","id":"6d60d1e7-088a-4a3e-9e90-33eeeaff694e"}',
'{"level":"error","ts":1658178238.4985926,"caller":"agent/logging.go:49","msg":"ERROR mqtt log","payload":["[client] ","Connect comms goroutine - error triggered",{}]}', '{"level":"error","ts":1658178238.4987323,"caller":"agent/comms.go:29","msg":"connection to mqtt lost","#attempt":0,"error":"EOF"}', '{"level":"error","ts":1658178238.4987314,"caller":"agent/heartbeats.go:96","msg":"error sending heartbeat","error":"connection lost before Publish completed"}', 
'{"level":"error","ts":1658178238.4987376,"caller":"agent/comms.go:61","msg":"failed to subscribe to agent control plane RPC topic","topic":"channels/d3b246fd-e3a2-42ee-904f-1876510694f0/messages/fromcore","error":"connection lost before Subscribe completed"}', '{"level":"info","ts":1658178238.4987504,"caller":"cloud_config/cloud_config.go:173","msg":"using explicitly specified cloud configuration","address":"tls://stg.orb.live:8883","id":"6d60d1e7-088a-4a3e-9e90-33eeeaff694e"}', 
'{"level":"info","ts":1658178238.498757,"caller":"agent/agent.go:154","msg":"stopping agent"}', 
'{"level":"info","ts":1658178239.5807369,"caller":"pktvisor/pktvisor.go:261","msg":"pktvisor stdout","log":"[2022-07-18 21:03:59.580] [visor] [info] REQUEST: GET /api/v1/metrics/app 200"}', 
'{"level":"info","ts":1658178239.580852,"caller":"pktvisor/pktvisor.go:261","msg":"pktvisor stdout","log":"[2022-07-18 21:03:59.580] [visor] [info] REQUEST: GET /api/v1/taps 200"}', 
'{"level":"info","ts":1658178239.5809326,"caller":"agent/rpc_to.go:50","msg":"sending capabilities","value":"{//"schema_version//"://"1.0//",//"orb_agent//":{//"version//"://"0.17.0-47a678aa//"},//"agent_tags//":null,//"backends//":{//"pktvisor//":{//"version//"://"4.2.0-develop-ec9d0ed//",//"data//":{//"taps//":{//"default_pcap//":{//"config//":{//"iface//"://"eno2//"},//"input_type//"://"pcap//",//"interface//"://"visor.module.input/1.0//"}}}}}}"}', 
'{"level":"info","ts":1658178239.791269,"caller":"pktvisor/pktvisor.go:422","msg":"pktvisor stopping"}', 
'{"level":"info","ts":1658178239.7914858,"caller":"pktvisor/pktvisor.go:261","msg":"pktvisor stdout","log":"[2022-07-18 21:03:59.791] [visor] [info] Shutting down"}', 
'{"level":"info","ts":1658178244.5825307,"caller":"pktvisor/pktvisor.go:261","msg":"pktvisor stdout","log":"[2022-07-18 21:04:04.582] [visor] [info] exit with success"}', 
'{"level":"info","ts":1658178244.583666,"caller":"pktvisor/pktvisor.go:435","msg":"pktvisor process stopped","pid":20,"exit_code":0}', 
'{"level":"fatal","ts":1658178244.583812,"caller":"agent/comms.go:63","msg":"critical failure: unable to subscribe to control plane"}', 
```