### PR TITLE
fix(orb-ui): #1457 Enable reset button only when agent is online or stale

### DIFF
--- a/ui/src/app/shared/components/orb/agent/agent-information/agent-information.component.html
+++ b/ui/src/app/shared/components/orb/agent/agent-information/agent-information.component.html
@@ -31,7 +31,7 @@
     <hr>
     <div class="block">
       <button (click)="resetAgent()"
-              [disabled]="isResetting"
+              [disabled]="isResetting || agent?.state === 'new' || agent?.state === 'offline'"
               class="agent-reset"
               data-orb-qa-id="button#reset"
               nbButton


### PR DESCRIPTION
### Description
**Issue:** https://github.com/ns1labs/orb/issues/1457
Enabled reset button only when agent is online or stale

Demo:
![image](https://user-images.githubusercontent.com/42921279/179048461-b8c372a4-6b23-4861-9f29-1deba0f5b6b1.png)

![image](https://user-images.githubusercontent.com/42921279/179048720-93289f2f-026a-4b51-81be-acfd0e566650.png)


