### PR TITLE
Hotfix/orb 1455 - apply edited policy and 1421 -  Name conflict error in editing policy returns 500 instead of 409

### DIFF
--- a/policies/postgres/policies.go
+++ b/policies/postgres/policies.go
@@ -68,6 +68,8 @@ func (r policiesRepository) UpdatePolicy(ctx context.Context, owner string, plcy
 			switch pqErr.Code.Name() {
 			case db.ErrInvalid, db.ErrTruncation:
 				return errors.Wrap(policies.ErrMalformedEntity, err)
+			case db.ErrDuplicate:
+				return errors.Wrap(errors.ErrConflict, err)
 			}
 		}
 		return errors.Wrap(fleet.ErrUpdateEntity, err)

--- a/policies/redis/producer/streams.go
+++ b/policies/redis/producer/streams.go
@@ -188,8 +188,8 @@ func (e eventStore) EditPolicy(ctx context.Context, token string, pol policies.P
 	}
 
 	event := updatePolicyEvent{
-		id:       pol.ID,
-		ownerID:  pol.MFOwnerID,
+		id:       editedPol.ID,
+		ownerID:  editedPol.MFOwnerID,
 		groupIDs: strings.Join(groupsIDs, ","),
 	}
 	record := &redis.XAddArgs{


### PR DESCRIPTION
Agent is not applying policy changes after editing because fleet service is failing to handle policy RPC messages for updating policy because of a malformed issue. Policy object that is being used to fill in RPC message does not contain OwnerID, we are only able to get it after the service layer, so we must use the policy object after editing

![image](https://user-images.githubusercontent.com/86990690/179248784-07c21017-3510-4fcd-9d01-e102c739c72e.png)


![image](https://user-images.githubusercontent.com/86990690/179248620-3121d060-5dab-4574-9953-9fc356104b74.png)


Also a minor fix to return 409 error code in case of name conflict for editing policy:

![conflict-error](https://user-images.githubusercontent.com/86990690/179059705-407a5e3e-76db-4775-bf04-b709b090fff6.png)
