### PR TITLE
fix(orb-ui): #1015 Make advanced options button look clickable

### DIFF
--- a/ui/src/app/pages/datasets/policies.agent/add/agent.policy.add.component.html
+++ b/ui/src/app/pages/datasets/policies.agent/add/agent.policy.add.component.html
@@ -198,7 +198,7 @@
                 </div>
                 <nb-accordion>
                   <nb-accordion-item>
-                    <nb-accordion-item-header>
+                    <nb-accordion-item-header class="policy-advanced-options">
                       <label>Advanced Options</label>
                     </nb-accordion-item-header>
                     <nb-accordion-item-body>

--- a/ui/src/app/pages/datasets/policies.agent/add/agent.policy.add.component.scss
+++ b/ui/src/app/pages/datasets/policies.agent/add/agent.policy.add.component.scss
@@ -129,20 +129,26 @@ mat-chip nb-icon {
 
 ::ng-deep nb-accordion {
   padding: 0 !important;
-  text-subtitle-line-height: 1rem;
   display: grid;
 
   nb-accordion-item {
     padding: 0 !important;
-    background: rgb(23, 28, 48);
+    background: rgb(23, 28, 48) !important;
 
-    nb-accordion-item-header {
-      padding: 0 !important;
+    .policy-advanced-options {
       background: rgb(23, 28, 48);
+      border-bottom: 1px solid rgba(150, 159, 185, 0.5) !important;
+      border-radius: 0 0 4px;
+      margin: 1rem 0;
+      padding: 0.4375rem  0 !important;
+
+      label {
+        cursor: pointer;
+        margin-bottom: 0 !important;
+      }
     }
 
     nb-accordion-item-body {
-      padding: 0 !important;
       background: rgb(23, 28, 48);
       display: grid;
     }


### PR DESCRIPTION
### Description
**Issue:** https://github.com/ns1labs/orb/issues/1015
In this PR I've made some small adjustements to make advanced options button look clickable. I thought it was a better idea to create a new class so I wouldn't risk to override another nb-accordion-header across the portal.

### Before:
![image](https://user-images.githubusercontent.com/42921279/179307270-c12679f1-36fe-41c3-ab78-33e3a07066e5.png)


### Now:
https://user-images.githubusercontent.com/42921279/179307179-0302f752-b1ec-4b40-a0f1-064cbb3418ed.mp4