### PR TITLE
fix(orb-ui): #1471 Remove selection from reload button once clicked and make it rotate while fetching data

### DIFF
--- a/ui/src/app/shared/components/poll-control/poll-control.component.html
+++ b/ui/src/app/shared/components/poll-control/poll-control.component.html
@@ -1,6 +1,7 @@
 <span *ngIf="lastUpdate$ | async">
-  <button nbButton ghost shape="round" (click)="forceRefresh()">
-    <i class="fa fa-redo" style="color: #3089fc;">&nbsp;</i></button
-  >
+  <button nbButton ghost  [className]="'refresh-button'" shape="round" (click)="forceRefresh()">
+    <i class="fa fa-redo" [ngClass]="loading == true ? 'rotate' : 'paused'" style="color: #3089fc;">&nbsp;</i>
+  </button
+>
   Last Update: {{ lastUpdate$ | async | date: 'mediumTime' }}
 </span>

--- a/ui/src/app/shared/components/poll-control/poll-control.component.scss
+++ b/ui/src/app/shared/components/poll-control/poll-control.component.scss
@@ -2,3 +2,41 @@
   color: #969fb9;
   font-size: 12px;
 }
+
+.refresh-button {
+  border: none !important;
+  box-sizing: border-box;
+  box-shadow: none !important;
+  margin-right: 0.3rem;
+
+  &:active, &:focus {
+    background-color: unset !important;
+  }
+
+  &:hover {
+    background-color: rgba(143, 155, 179, 0.16);
+  }
+}
+
+.paused {
+  animation: rotation 750ms linear infinite;
+  animation-play-state: paused;
+}
+
+.rotate {
+  animation: rotation 750ms linear infinite;
+  animation-play-state: running;
+
+  &:hover {
+    background: unset !important;
+  }
+}
+
+@keyframes rotation {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(359deg);
+  }
+}

--- a/ui/src/app/shared/components/poll-control/poll-control.component.ts
+++ b/ui/src/app/shared/components/poll-control/poll-control.component.ts
@@ -10,16 +10,24 @@ import { shareReplay } from 'rxjs/operators';
 })
 export class PollControlComponent implements OnInit {
   lastUpdate$: Observable<number>;
+  loading: boolean;
 
   constructor(private orb: OrbService) {
     this.lastUpdate$ = this.orb.lastPollUpdate$
       .asObservable()
       .pipe(shareReplay());
+    this.loading = false;
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.lastUpdate$.subscribe(() => {
+      this.loading = false;
+    });
+  }
 
   forceRefresh() {
+    this.loading = true;
+
     this.orb.refreshNow();
   }
 }


### PR DESCRIPTION
### Description
**Issue**: https://github.com/ns1labs/orb/issues/1471
I have fixed the active/focus effect, styled it a little bit and also added an animation while it is fetching the data.

**Before:**
![image](https://user-images.githubusercontent.com/42921279/179324900-251d0f02-7fb8-4e4b-ac37-63ad3d4a7247.png)


**Now:**

https://user-images.githubusercontent.com/42921279/179325184-91c5582f-5a0f-4336-99ec-d7b45cacd865.mp4


