### PR TITLE
fix(orb-ui): #1470 Dismiss dataset modal when clicking outside it

### DIFF
--- a/ui/src/app/shared/components/orb/agent/agent-policies-datasets/agent-policies-datasets.component.ts
+++ b/ui/src/app/shared/components/orb/agent/agent-policies-datasets/agent-policies-datasets.component.ts
@@ -110,7 +110,8 @@ export class AgentPoliciesDatasetsComponent implements OnInit {
           dataset,
         },
         hasScroll: false,
-        hasBackdrop: false,
+        hasBackdrop: true,
+        closeOnBackdropClick: true,
       })
       .onClose.subscribe((resp) => {
         if (resp === 'changed' || 'deleted') {


### PR DESCRIPTION
### Description
**Issue:** https://github.com/ns1labs/orb/issues/1470
Fixed behaviour where dataset modal would not close on click outside

**Before:**
![image](https://user-images.githubusercontent.com/42921279/179526411-44600568-cbba-4ce8-be54-efc5e7755e7d.png)

**Now:**

https://user-images.githubusercontent.com/42921279/179526645-9d489c56-078e-4a2e-96fc-eebadabb8c95.mp4
