### PR TITLE
fix(orb-ui): #1502 Align policy names at the left of table row

### DIFF
--- a/ui/src/app/pages/datasets/policies.agent/list/agent.policy.list.component.scss
+++ b/ui/src/app/pages/datasets/policies.agent/list/agent.policy.list.component.scss
@@ -146,6 +146,7 @@ tr div p {
   outline: none !important;
   overflow: hidden !important;
   color: #ffffff;
+  text-align: left;
 }
 
 .add-agent-policy-container {


### PR DESCRIPTION
### Description
**Issue:** https://github.com/ns1labs/orb/issues/1502

Align policy names at the left of table row

**Demo:**
![image](https://user-images.githubusercontent.com/42921279/179602054-150bb2be-a100-4985-a7c2-8c757d094b98.png)
