### PR TITLE
fix(orb-ui): #1500 Handle exception thrown when failing to create or edit a new policy

### DIFF
--- a/ui/src/app/common/services/agents/agent.policies.service.ts
+++ b/ui/src/app/common/services/agents/agent.policies.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, of } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import 'rxjs/add/observable/empty';
 
 import { environment } from 'environments/environment';
@@ -66,11 +66,7 @@ export class AgentPoliciesService {
         return resp.body as AgentPolicy;
       })
       .catch((err) => {
-        this.notificationsService.error(
-          'Failed to create Agent Policy',
-          `Error: ${err.status} - ${err.statusText} - ${err.error.error}`,
-        );
-        return of(err);
+        return throwError(err);
       });
   }
 
@@ -111,11 +107,7 @@ export class AgentPoliciesService {
     return this.http
       .put(`${environment.agentPoliciesUrl}/${agentPolicy.id}`, agentPolicy)
       .catch((err) => {
-        this.notificationsService.error(
-          'Failed to edit Agent Policy',
-          `Error: ${err.status} - ${err.statusText}`,
-        );
-        return of(err);
+        return throwError(err);
       });
   }
 

--- a/ui/src/app/pages/datasets/policies.agent/add/agent.policy.add.component.ts
+++ b/ui/src/app/pages/datasets/policies.agent/add/agent.policy.add.component.ts
@@ -512,15 +512,31 @@ kind: collection`;
   submit(payload) {
     if (this.isEdit) {
       // updating existing sink
-      this.agentPoliciesService.editAgentPolicy({ ...payload, id: this.agentPolicyID }).subscribe(() => {
-        this.notificationsService.success('Agent Policy successfully updated', '');
-        this.viewPolicy(this.agentPolicyID);
-      });
+      this.agentPoliciesService.editAgentPolicy({ ...payload, id: this.agentPolicyID }).subscribe(
+        (next) => {
+          this.notificationsService.success('Agent Policy successfully updated', '');
+          this.viewPolicy(this.agentPolicyID);
+        },
+        (error) => {
+          this.notificationsService.error(
+            'Failed to edit Agent Policy',
+            `Error: ${error.status} - ${error.statusText}`,
+          );
+        },
+      );
     } else {
-      this.agentPoliciesService.addAgentPolicy(payload).subscribe(next => {
-        this.notificationsService.success('Agent Policy successfully created', '');
-        this.viewPolicy(next.id);
-      });
+      this.agentPoliciesService.addAgentPolicy(payload).subscribe(
+        (next) => {
+          this.notificationsService.success('Agent Policy successfully created', '');
+          this.viewPolicy(next.id);
+        },
+        (error) => {
+          this.notificationsService.error(
+            'Failed to create Agent Policy',
+            `Error: ${error.status} - ${error.statusText} - ${error.error.error}`,
+          );
+        },
+      );
     }
   }
 }


### PR DESCRIPTION
**Issue:** https://github.com/ns1labs/orb/issues/1500

### Description
When trying to create a policy which name was already used before, the user was being redirected to a broken policy view page.
I've mapped the service exception that is thrown from Agent Policy component and also removed the notifications from service to component.

**Before:**
![image](https://user-images.githubusercontent.com/42921279/179791637-c2820ec9-2503-4ed3-b3b1-ee8c53dae414.png)

**After:**

https://user-images.githubusercontent.com/42921279/179792086-5e4fa147-79e6-4a4c-b095-94a9fbd9909b.mp4


