### PR TITLE
Fix/remove policy stream

### DIFF
--- a/policies/api/http/logging.go
+++ b/policies/api/http/logging.go
@@ -18,6 +18,20 @@ type loggingMiddleware struct {
 	svc    policies.Service
 }
 
+func (l loggingMiddleware) RemoveAllDatasetsByPolicyIDInternal(ctx context.Context, token string, policyID string) (err error) {
+	defer func(begin time.Time) {
+		if err != nil {
+			l.logger.Warn("method call: remove_all_datasets_by_policy_id_internal",
+				zap.Error(err),
+				zap.Duration("duration", time.Since(begin)))
+		} else {
+			l.logger.Info("method call: remove_all_datasets_by_policy_id_internal",
+				zap.Duration("duration", time.Since(begin)))
+		}
+	}(time.Now())
+	return l.svc.RemoveAllDatasetsByPolicyIDInternal(ctx, token, policyID)
+}
+
 func (l loggingMiddleware) InactivateDatasetByIDInternal(ctx context.Context, ownerID string, datasetID string) (err error) {
 	defer func(begin time.Time) {
 		if err != nil {

--- a/policies/api/http/metrics.go
+++ b/policies/api/http/metrics.go
@@ -22,6 +22,28 @@ type metricsMiddleware struct {
 	svc     policies.Service
 }
 
+func (m metricsMiddleware) RemoveAllDatasetsByPolicyIDInternal(ctx context.Context, token string, policyID string) error {
+	ownerID, err := m.identify(token)
+	if err != nil {
+		return err
+	}
+
+	defer func(begin time.Time) {
+		labels := []string{
+			"method", "removeAllDatasetsByPolicyIDInternal",
+			"owner_id", ownerID,
+			"policy_id", policyID,
+			"dataset_id", "",
+		}
+
+		m.counter.With(labels...).Add(1)
+		m.latency.With(labels...).Observe(float64(time.Since(begin).Microseconds()))
+
+	}(time.Now())
+
+	return m.svc.RemoveAllDatasetsByPolicyIDInternal(ctx, token, policyID)
+}
+
 func (m metricsMiddleware) InactivateDatasetByIDInternal(ctx context.Context, ownerID string, datasetID string) error {
 	defer func(begin time.Time) {
 		labels := []string{

--- a/policies/policies.go
+++ b/policies/policies.go
@@ -118,6 +118,9 @@ type Service interface {
 
 	// DuplicatePolicy duplicates existing agent Policy
 	DuplicatePolicy(ctx context.Context, token string, policyID string, name string) (Policy, error)
+
+	// RemoveAllDatasetsByPolicyIDInternal removes all datasets by policyID owned by the specified user
+	RemoveAllDatasetsByPolicyIDInternal(ctx context.Context, token string, policyID string) error
 }
 
 type Repository interface {

--- a/policies/policy_service.go
+++ b/policies/policy_service.go
@@ -185,12 +185,21 @@ func (s policiesService) RemovePolicy(ctx context.Context, token string, policyI
 		return err
 	}
 
-	err = s.repo.DeleteAllDatasetsPolicy(ctx, policyID, ownerID)
+	err = s.repo.DeletePolicy(ctx, ownerID, policyID)
 	if err != nil {
 		return err
 	}
 
-	err = s.repo.DeletePolicy(ctx, ownerID, policyID)
+	return nil
+}
+
+func (s policiesService) RemoveAllDatasetsByPolicyIDInternal(ctx context.Context, token string, policyID string) error {
+	ownerID, err := s.identify(token)
+	if err != nil {
+		return err
+	}
+
+	err = s.repo.DeleteAllDatasetsPolicy(ctx, policyID, ownerID)
 	if err != nil {
 		return err
 	}

--- a/policies/policy_service_test.go
+++ b/policies/policy_service_test.go
@@ -1377,6 +1377,66 @@ func TestDeleteAGroupFromDataset(t *testing.T) {
 	}
 }
 
+func TestRemoveAllDatasetsByPolicyIDInternal(t *testing.T) {
+	users := flmocks.NewAuthService(map[string]string{token: email})
+	svc := newService(users)
+
+	policy := createPolicy(t, svc, "policy")
+	ds := createDataset(t, svc, "dataset")
+
+	for i := 0; i < limit; i++ {
+		nameID, err := types.NewIdentifier(fmt.Sprintf("new-dataset-%d", i))
+		require.Nil(t, err, fmt.Sprintf("Unexpected error: %s", err))
+
+		svc.AddDataset(context.Background(), token, policies.Dataset{
+			Name:         nameID,
+			MFOwnerID:    ds.MFOwnerID,
+			AgentGroupID: ds.AgentGroupID,
+			PolicyID:     policy.ID,
+			SinkIDs:      ds.SinkIDs,
+		})
+	}
+
+	cases := map[string]struct {
+		policyID string
+		token    string
+		remove   bool
+		err      error
+	}{
+		"delete existing dataset with existing policyID": {
+			policyID: policy.ID,
+			token:    token,
+			remove:   true,
+			err:      nil,
+		},
+		"delete datasets with no existing policyID": {
+			policyID: wrongID,
+			token:    token,
+			remove:   false,
+			err:      nil,
+		},
+		"delete dataset with wrong credentials": {
+			policyID: policy.ID,
+			token:    invalidToken,
+			remove:   false,
+			err:      policies.ErrUnauthorizedAccess,
+		},
+	}
+
+	for desc, tc := range cases {
+		t.Run(desc, func(t *testing.T) {
+			err := svc.RemoveAllDatasetsByPolicyIDInternal(context.Background(), tc.token, tc.policyID)
+			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s", desc, tc.err, err))
+
+			if tc.remove {
+				ds, err := svc.ListDatasetsByPolicyIDInternal(context.Background(), tc.policyID, tc.token)
+				require.Nil(t, err, fmt.Sprintf("Unexpected error: %s", err))
+				assert.True(t, assert.Equal(t, len(ds), 0), fmt.Sprintf("%s: expected %d got %d", desc, 0, len(ds)))
+			}
+		})
+	}
+}
+
 func testSortPolicies(t *testing.T, pm policies.PageMetadata, ags []policies.Policy) {
 	t.Helper()
 	switch pm.Order {

--- a/policies/policy_service_test.go
+++ b/policies/policy_service_test.go
@@ -310,9 +310,6 @@ func TestRemovePolicy(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 			err := svc.RemovePolicy(context.Background(), tc.token, tc.id)
 			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s", desc, tc.err, err))
-
-			_, err = svc.ViewDatasetByID(context.Background(), token, tc.datasetID)
-			assert.True(t, errors.Contains(policies.ErrNotFound, err), fmt.Sprintf("%s: expected %s got %s", desc, policies.ErrNotFound, err))
 		})
 	}
 }

--- a/policies/redis/producer/streams.go
+++ b/policies/redis/producer/streams.go
@@ -130,6 +130,11 @@ func (e eventStore) RemovePolicy(ctx context.Context, token string, policyID str
 		return err
 	}
 
+	err = e.svc.RemoveAllDatasetsByPolicyIDInternal(ctx, token, policyID)
+	if err != nil {
+		return err
+	}
+
 	if len(datasets) == 0 {
 		return nil
 	}
@@ -307,6 +312,10 @@ func (e eventStore) DeleteAgentGroupFromAllDatasets(ctx context.Context, groupID
 
 func (e eventStore) DuplicatePolicy(ctx context.Context, token string, policyID string, name string) (policies.Policy, error) {
 	return e.svc.DuplicatePolicy(ctx, token, policyID, name)
+}
+
+func (e eventStore) RemoveAllDatasetsByPolicyIDInternal(ctx context.Context, token string, policyID string) error {
+	return e.svc.RemoveAllDatasetsByPolicyIDInternal(ctx, token, policyID)
 }
 
 // NewEventStoreMiddleware returns wrapper around policies service that sends

--- a/policies/redis/producer/streams.go
+++ b/policies/redis/producer/streams.go
@@ -132,7 +132,7 @@ func (e eventStore) RemovePolicy(ctx context.Context, token string, policyID str
 
 	err = e.svc.RemoveAllDatasetsByPolicyIDInternal(ctx, token, policyID)
 	if err != nil {
-		return err
+		e.logger.Error("error while removing datasets", zap.Error(err))
 	}
 
 	if len(datasets) == 0 {


### PR DESCRIPTION
Today's behavior deletes the dataset before sending the RPC stream, but dataset info is needed to fill the message and because of that the message was not being published. This result in the agent not removing the policy. Thus this PR extracts the deletion of datasets belonging to specified policy to a separated service and only deleting after fetching the dataset's info