### PR TITLE
feat(orb-ui): #1521 Allow users to duplicate policies in Policy Management page

### DIFF
--- a/ui/src/app/pages/datasets/policies.agent/list/agent.policy.list.component.html
+++ b/ui/src/app/pages/datasets/policies.agent/list/agent.policy.list.component.html
@@ -82,6 +82,14 @@
       <nb-icon icon="edit-outline"></nb-icon>
     </button>
     <button
+      (click)="duplicatePolicy(row)"
+      ghost
+      nbTooltip="Duplicate"
+      nbButton
+    >
+      <nb-icon icon="copy-outline"></nb-icon>
+    </button>
+    <button
       (click)="openDeleteModal(row)"
       class="orb-action-hover del-button"
       ghost

--- a/ui/src/app/pages/datasets/policies.agent/list/agent.policy.list.component.ts
+++ b/ui/src/app/pages/datasets/policies.agent/list/agent.policy.list.component.ts
@@ -110,6 +110,23 @@ export class AgentPolicyListComponent
     );
   }
 
+  duplicatePolicy(agentPolicy: any) {
+    this.agentPoliciesService
+      .duplicateAgentPolicy(agentPolicy.id)
+      .subscribe((newAgentPolicy) => {
+        if (newAgentPolicy?.id) {
+          this.notificationsService.success(
+            'Agent Policy Duplicated',
+            `New Agent Policy Name: ${newAgentPolicy?.name}`,
+          );
+
+          this.router.navigate([`view/${newAgentPolicy.id}`], {
+            relativeTo: this.route,
+          });
+        }
+      });
+  }
+
   ngAfterViewChecked() {
     if (
       this.table &&


### PR DESCRIPTION
**Issue**: https://github.com/ns1labs/orb/issues/1521

### Description
Create button like view|edit|delete to duplicate policy, redirect user to the new policy created and leave a notification whether this process was completed successfully or not.

### Demo:

https://user-images.githubusercontent.com/42921279/180074010-c26b11c4-1399-44f7-ae20-f38ced9ca92b.mp4

