### PR TITLE
feature(orb-ui): #1478 Improve agent and backend version label and pattern

### DIFF
--- a/ui/src/app/shared/components/orb/agent/agent-information/agent-information.component.html
+++ b/ui/src/app/shared/components/orb/agent/agent-information/agent-information.component.html
@@ -10,9 +10,9 @@
       </div>
       <div class="col-6">
         <div class="float-right">
-          <label>Version</label>
-          <p>{{ agent?.agent_metadata?.orb_agent?.version }}</p>
-          <label>Version</label>
+          <label>Agent Version</label>
+          <p>{{ getAgentVersion() }}</p>
+          <label>Backend Version</label>
           <p>{{ getAgentBackendVersion() }}</p>
         </div>
       </div>

--- a/ui/src/app/shared/components/orb/agent/agent-information/agent-information.component.ts
+++ b/ui/src/app/shared/components/orb/agent/agent-information/agent-information.component.ts
@@ -32,6 +32,12 @@ export class AgentInformationComponent implements OnInit {
     }
   }
 
+  getAgentVersion() {
+    const agentVersion = this.agent?.agent_metadata?.orb_agent?.version;
+
+    return agentVersion ? agentVersion : '-';
+  }
+
   getAgentBackend() {
     const {backends} = this.agent.agent_metadata;
     const backend = !!backends && Object.keys(backends).length > 0 ? Object.keys(backends)[0] : '-';


### PR DESCRIPTION
**Issue**: https://github.com/ns1labs/orb/issues/1478

### Description
- All empty fields now have a consistent pattern and are filled with a "-"
- Labels renamed to "Agent version" and "Backend version"

### Before:
![image](https://user-images.githubusercontent.com/42921279/180088789-76d4a693-fd8a-4714-8588-bef233598a01.png)

### Now:
![image](https://user-images.githubusercontent.com/42921279/180088842-bbdd7487-2300-4f1c-8d5c-03a2030f82fa.png)
