### PR TITLE
fix(services): fix ts encoding as iso

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -73,12 +73,17 @@ func Run(cmd *cobra.Command, args []string) {
 	} else {
 		atomicLevel.SetLevel(zap.InfoLevel)
 	}
+	encoderCfg := zap.NewProductionEncoderConfig()
+	encoderCfg.EncodeTime = zapcore.ISO8601TimeEncoder
 	core := zapcore.NewCore(
-		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.NewJSONEncoder(encoderCfg),
 		os.Stdout,
 		atomicLevel,
 	)
 	logger = zap.New(core, zap.AddCaller())
+	defer func(logger *zap.Logger) {
+		_ = logger.Sync()
+	}(logger)
 
 	// new agent
 	a, err := agent.New(logger, config)

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -37,8 +37,10 @@ func init() {
 		atomicLevel.SetLevel(zap.InfoLevel)
 	}
 
+	encoderCfg := zap.NewProductionEncoderConfig()
+	encoderCfg.EncodeTime = zapcore.ISO8601TimeEncoder
 	core := zapcore.NewCore(
-		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.NewJSONEncoder(encoderCfg),
 		os.Stdout,
 		atomicLevel,
 	)

--- a/cmd/policies/main.go
+++ b/cmd/policies/main.go
@@ -26,6 +26,7 @@ import (
 	sinkspb "github.com/ns1labs/orb/sinks/pb"
 	opentracing "github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc/reflection"
 	"io"
 	"io/ioutil"
@@ -35,6 +36,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -67,14 +69,30 @@ func main() {
 	policiesGRPCCfg := config.LoadGRPCConfig("orb", "policies")
 	sinksGRPCCfg := config.LoadGRPCConfig("orb", "sinks")
 
-	// main logger
+	// logger
 	var logger *zap.Logger
-	if svcCfg.LogLevel == "debug" {
-		logger, _ = zap.NewDevelopment()
-	} else {
-		logger, _ = zap.NewProduction()
+	atomicLevel := zap.NewAtomicLevel()
+	switch strings.ToLower(svcCfg.LogLevel) {
+	case "debug":
+		atomicLevel.SetLevel(zap.DebugLevel)
+	case "warn":
+		atomicLevel.SetLevel(zap.WarnLevel)
+	case "info":
+		atomicLevel.SetLevel(zap.InfoLevel)
+	default:
+		atomicLevel.SetLevel(zap.InfoLevel)
 	}
-	defer logger.Sync() // flushes buffer, if any
+	encoderCfg := zap.NewProductionEncoderConfig()
+	encoderCfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(encoderCfg),
+		os.Stdout,
+		atomicLevel,
+	)
+	logger = zap.New(core, zap.AddCaller())
+	defer func(logger *zap.Logger) {
+		_ = logger.Sync()
+	}(logger)
 
 	db := connectToDB(dbCfg, logger)
 	defer db.Close()

--- a/cmd/sinker/main.go
+++ b/cmd/sinker/main.go
@@ -77,8 +77,10 @@ func main() {
 	default:
 		atomicLevel.SetLevel(zap.InfoLevel)
 	}
+	encoderCfg := zap.NewProductionEncoderConfig()
+	encoderCfg.EncodeTime = zapcore.ISO8601TimeEncoder
 	core := zapcore.NewCore(
-		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.NewJSONEncoder(encoderCfg),
 		os.Stdout,
 		atomicLevel,
 	)


### PR DESCRIPTION
This fixes ns1labs/orb#1463
Logs now

Fleet
```
{"level":"info","ts":"2022-07-21T17:18:40.514Z","caller":"fleet/main.go:289","msg":"Dialed to gRPC service auth at kind-orb-envoy:8181, TLS? false"}
{"level":"info","ts":"2022-07-21T17:18:40.514Z","caller":"fleet/main.go:289","msg":"Dialed to gRPC service policies at kind-orb-envoy:8282, TLS? false"}
{"level":"info","ts":"2022-07-21T17:18:40.516Z","caller":"fleet/comms.go:745","msg":"subscribed to agent channels"}
{"level":"info","ts":"2022-07-21T17:18:40.516Z","caller":"fleet/main.go:302","msg":"Fleet service started using http on port 8203"}
{"level":"info","ts":"2022-07-21T17:18:40.516Z","caller":"fleet/main.go:333","msg":"gRPC service started using http on port 8283"}
{"level":"info","ts":"2022-07-21T17:18:40.516Z","caller":"fleet/agent_state_check.go:16","msg":"checking for stale agents"}
{"level":"info","ts":"2022-07-21T17:18:40.516Z","caller":"fleet/main.go:308","msg":"Subscribed to Redis Event Store for policies"}
{"level":"info","ts":"2022-07-21T17:19:40.516Z","caller":"fleet/agent_state_check.go:16","msg":"checking for stale agents"}
```

Policies
```
{"level":"info","ts":"2022-07-21T17:18:30.624Z","caller":"policies/main.go:249","msg":"Dialed to gRPC service auth at kind-orb-envoy:8181, TLS? false"}
{"level":"info","ts":"2022-07-21T17:18:30.624Z","caller":"policies/main.go:249","msg":"Dialed to gRPC service fleet at kind-orb-envoy:8283, TLS? false"}
{"level":"info","ts":"2022-07-21T17:18:30.624Z","caller":"policies/main.go:249","msg":"Dialed to gRPC service sinks at kind-orb-envoy:8280, TLS? false"}
{"level":"info","ts":"2022-07-21T17:18:30.624Z","caller":"policies/main.go:262","msg":"Policies service started using http on port 8202"}
{"level":"info","ts":"2022-07-21T17:18:30.624Z","caller":"policies/main.go:285","msg":"gRPC service started using http on port 8282"}
{"level":"info","ts":"2022-07-21T17:18:30.624Z","caller":"policies/main.go:304","msg":"Subscribed to Redis Event Store for sinks"}
{"level":"info","ts":"2022-07-21T17:18:30.624Z","caller":"policies/main.go:296","msg":"Subscribed to Redis Event Store for agent groups"}
```

Sinker
```
{"level":"info","ts":"2022-07-21T17:17:44.514Z","caller":"sinker/main.go:234","msg":"Dialed to gRPC service policies at kind-orb-envoy:8282, TLS? false"}
{"level":"info","ts":"2022-07-21T17:17:44.514Z","caller":"sinker/main.go:234","msg":"Dialed to gRPC service fleet at kind-orb-envoy:8283, TLS? false"}
{"level":"info","ts":"2022-07-21T17:17:44.514Z","caller":"sinker/main.go:234","msg":"Dialed to gRPC service sinks at kind-orb-envoy:8280, TLS? false"}
{"level":"info","ts":"2022-07-21T17:17:44.514Z","caller":"sinker/service.go:281","msg":"started metrics consumer","topic":"channels.*.be.*.m.>"}
{"level":"info","ts":"2022-07-21T17:17:44.514Z","caller":"sinker/main.go:192","msg":"Sinker service started using http on port 8201"}
{"level":"info","ts":"2022-07-21T17:17:44.514Z","caller":"sinker/main.go:265","msg":"Subscribed to Redis Event Store for sinks"}
```

Sinks
```
{"level":"info","ts":"2022-07-21T17:18:29.485Z","caller":"sinks/main.go:225","msg":"gRPC communication is not encrypted"}
{"level":"info","ts":"2022-07-21T17:18:29.486Z","caller":"sinks/main.go:245","msg":"Sink service started using http on port 8200"}
{"level":"info","ts":"2022-07-21T17:18:29.486Z","caller":"sinks/main.go:268","msg":"gRPC service started using http on port 8280"}
{"level":"info","ts":"2022-07-21T17:18:29.486Z","caller":"sinks/main.go:278","msg":"Subscribed to Redis Event Store for sinker"}
```