### PR TITLE
feature(orb-ui): #1547 Only add filter property if it is not empty and if it is valid

### DIFF
--- a/ui/src/app/pages/datasets/policies.agent/add/agent.policy.add.component.ts
+++ b/ui/src/app/pages/datasets/policies.agent/add/agent.policy.add.component.ts
@@ -423,7 +423,7 @@ kind: collection`;
     this.modules[name] = ({
       type,
       config,
-      ...(filter.length > 0) && filter,
+      ...(filter !== undefined && filter.length > 0) && filter,
     });
 
   }


### PR DESCRIPTION
**Issue**: https://github.com/ns1labs/orb/issues/1547

### Description
If a DHCP or NET handler is set, it is created with an undefined filter. My commit ensures to check if is not undefined before checking its length for DNS. 

https://user-images.githubusercontent.com/42921279/180787451-41c273a3-100c-423d-a717-bf75aea4dff8.mp4

