### PR TITLE
fix(orb-ui): #1550 Display agent group name and description in column direction and set a limit to text container

### DIFF
--- a/ui/src/app/pages/fleet/groups/add/agent.group.add.component.html
+++ b/ui/src/app/pages/fleet/groups/add/agent.group.add.component.html
@@ -136,16 +136,16 @@
           </ng-template>
           <div
             *ngIf="!expanded"
-            class="d-flex row">
+            class="d-flex row column-direction">
             <div class="col-md-12 col-xl-6">
-              <div>
+              <div class="max-width-vw">
                 <label class="font-weight-bold">{{strings.propNames.name}}</label>
                 <p>{{firstFormGroup.controls.name.value}}</p>
               </div>
             </div>
             <hr/>
             <div class="col-md-12 col-xl-6">
-              <div>
+              <div class="max-width-vw">
                 <label class="font-weight-bold">{{strings.propNames.description}}</label>
                 <p>{{firstFormGroup.controls.description.value}}</p>
               </div>

--- a/ui/src/app/pages/fleet/groups/add/agent.group.add.component.scss
+++ b/ui/src/app/pages/fleet/groups/add/agent.group.add.component.scss
@@ -253,6 +253,14 @@ mat-chip-list {
   display: block;
 }
 
+.column-direction {
+  flex-direction: column;
+}
+
+.max-width-vw {
+  width: 50vw;
+}
+
 @keyframes slidetween {
   from {
     transform: translateX(0);


### PR DESCRIPTION
**Issue**: https://github.com/ns1labs/orb/issues/1550

### Description
Display agent group name and description in column direction and set a limit to text container

**Before:**

![image](https://user-images.githubusercontent.com/42921279/180847187-5d8882c0-60bd-4690-a996-6964f5ff991b.png)


**Now:**

![image](https://user-images.githubusercontent.com/42921279/180847085-97081bc8-375a-4fa5-ba46-f0987d624767.png)

