### PR TITLE
fix(orb-ui): #1122 Display a message to user when no agent groups or sinks are available

### DIFF
--- a/ui/src/app/pages/datasets/dataset-from/dataset-from.component.html
+++ b/ui/src/app/pages/datasets/dataset-from/dataset-from.component.html
@@ -24,6 +24,8 @@
 
                     <input
                             (input)="onChangeGroupName($event)"
+                            class="dataset-agent-group-input"
+                            [readonly]="fetchedData && !(availableAgentGroups.length > 0)"
                             [nbAutocomplete]="autoControl"
                             formControlName="agent_group_name"
                             nbInput
@@ -50,6 +52,9 @@
                         <div *ngIf="form.controls?.agent_group_id.errors?.required">
                             You must select a valid Agent Group.
                         </div>
+                    </div>
+                    <div class="required" *ngIf="fetchedData && !(availableAgentGroups.length > 0)"> 
+                        There are no agent groups available
                     </div>
                 </nb-form-field>
                 <br>
@@ -97,13 +102,20 @@
             <div>
                 <ngx-sink-display [(selectedSinks)]="selectedSinks"></ngx-sink-display>
                 <ngx-sink-control
-                        [(selectedSinks)]="selectedSinks"
-                        [sinksList]="unselectedSinks"></ngx-sink-control>
+                  [(selectedSinks)]="selectedSinks"
+                  [sinksList]="unselectedSinks"
+                ></ngx-sink-control>
                 <div
-                        *ngIf="sinkIDs.length === 0
-          && (form.controls?.sink_ids.dirty)"
-                        class="required">
-                    At least one Sink is required.
+                  *ngIf="sinkIDs.length === 0 && form.controls?.sink_ids.dirty"
+                  class="required"
+                >
+                  At least one Sink is required.
+                </div>
+                <div
+                  *ngIf="fetchedData && !(availableSinks.length > 0)"
+                  class="required"
+                >
+                  There are no sinks available
                 </div>
             </div>
             <!--      NAME-->

--- a/ui/src/app/pages/datasets/dataset-from/dataset-from.component.scss
+++ b/ui/src/app/pages/datasets/dataset-from/dataset-from.component.scss
@@ -220,3 +220,11 @@ nb-accordion {
   position: static !important;
   overflow-y: inherit !important;
 }
+
+.dataset-agent-group-input {
+  &:read-only {
+    background-color: #232940 !important;
+    cursor: default;
+    opacity: 0.5;
+  }
+}

--- a/ui/src/app/pages/datasets/dataset-from/dataset-from.component.ts
+++ b/ui/src/app/pages/datasets/dataset-from/dataset-from.component.ts
@@ -46,6 +46,7 @@ export class DatasetFromComponent implements OnInit {
   selectedGroup: string;
 
   selectedPolicy: string;
+  fetchedData: boolean;
   sinkIDs: string[];
   availableAgentGroups: AgentGroup[];
   filteredAgentGroups$: Observable<AgentGroup[]>;
@@ -71,6 +72,7 @@ export class DatasetFromComponent implements OnInit {
   ) {
     this.isEdit = false;
     this.availableAgentGroups = [];
+    this.fetchedData = false;
     this.filteredAgentGroups$ = of(this.availableAgentGroups);
     this.availableAgentPolicies = [];
     this.availableSinks = [];
@@ -220,7 +222,7 @@ export class DatasetFromComponent implements OnInit {
     ])
       .then(
         (value) => {
-          // console.log('warning');
+          this.fetchedData = true;
         },
         (reason) =>
           console.warn(


### PR DESCRIPTION
**Issue**: https://github.com/ns1labs/orb/issues/1122

### Description
Display a message to user when no agent groups or sinks are available

**Before**
![image](https://user-images.githubusercontent.com/42921279/181031933-07ee7923-5375-4af6-9af6-5eefb6d06fdc.png)

**Now**
![image](https://user-images.githubusercontent.com/42921279/181032154-83b7302f-c29e-4b51-84ba-250d31e4b63a.png)

