### PR TITLE
fix(orb-ui): #1543 Display policies that have a dataset which assigned group was removed

### DIFF
--- a/ui/src/app/common/services/orb.service.ts
+++ b/ui/src/app/common/services/orb.service.ts
@@ -172,9 +172,21 @@ export class OrbService implements OnDestroy {
                     .map((groupId) =>
                       !!groupId && groupId !== ''
                         ? this.group.getAgentGroupById(groupId)
-                        : EMPTY,
+                        : of({}),
                     ),
-                ).pipe(map((groups) => ({ datasets, groups, policy })))
+                ).pipe(
+                  map((groups) => {
+                    const filteredGroups = groups.filter(group => {
+                      if (Object.keys(group).length !== 0) {
+                        return true;
+                      }
+
+                      return false;
+                    });
+
+                    return ({ datasets, groups: filteredGroups, policy });
+                  }),
+              )
               : of({ datasets, groups: [], policy }),
           ),
           // same for sinks


### PR DESCRIPTION
**Issue**: https://github.com/ns1labs/orb/issues/1543

### Description
Display policies that have a dataset which assigned group was removed

**Before**
![image](https://user-images.githubusercontent.com/42921279/181126866-62f6c0ab-4fbb-4562-89cc-1ed6ae6d8800.png)


**Now**
https://user-images.githubusercontent.com/42921279/181127129-e5561cc3-3548-4b03-8789-b9ea9864b743.mp4






