### PR TITLE
Agent fix graceful stop and remove fatal

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -5,6 +5,7 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"github.com/eclipse/paho.mqtt.golang"
 	"github.com/fatih/structs"
@@ -25,18 +26,19 @@ var (
 )
 
 type Agent interface {
-	Start() error
-	Stop()
-	RestartAll(reason string) error
-	RestartBackend(backend string, reason string) error
+	Start(ctx context.Context, cancelFunc context.CancelFunc) error
+	Stop(ctx context.Context)
+	RestartAll(ctx context.Context, reason string) error
+	RestartBackend(ctx context.Context, backend string, reason string) error
 }
 
 type orbAgent struct {
-	logger   *zap.Logger
-	config   config.Config
-	client   mqtt.Client
-	db       *sqlx.DB
-	backends map[string]backend.Backend
+	logger         *zap.Logger
+	config         config.Config
+	client         mqtt.Client
+	db             *sqlx.DB
+	backends       map[string]backend.Backend
+	cancelFunction context.CancelFunc
 
 	hbTicker *time.Ticker
 	hbDone   chan bool
@@ -87,7 +89,7 @@ func New(logger *zap.Logger, c config.Config) (Agent, error) {
 	return &orbAgent{logger: logger, config: c, policyManager: pm, db: db, groupsInfos: make(map[string]GroupInfo)}, nil
 }
 
-func (a *orbAgent) startBackends() error {
+func (a *orbAgent) startBackends(agentCtx context.Context) error {
 	a.logger.Info("registered backends", zap.Strings("values", backend.GetList()))
 	a.logger.Info("requested backends", zap.Any("values", a.config.OrbAgent.Backends))
 	if len(a.config.OrbAgent.Backends) == 0 {
@@ -102,7 +104,8 @@ func (a *orbAgent) startBackends() error {
 		if err := be.Configure(a.logger, a.policyManager.GetRepo(), configurationEntry, structs.Map(a.config.OrbAgent.Otel)); err != nil {
 			return err
 		}
-		if err := be.Start(); err != nil {
+		backendCtx := context.WithValue(agentCtx, "routine", name)
+		if err := be.Start(context.WithCancel(backendCtx)); err != nil {
 			return err
 		}
 		a.backends[name] = be
@@ -110,10 +113,10 @@ func (a *orbAgent) startBackends() error {
 	return nil
 }
 
-func (a *orbAgent) Start() error {
-
-	a.logger.Info("agent started", zap.String("version", buildinfo.GetVersion()))
-
+func (a *orbAgent) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
+	agentCtx := context.WithValue(ctx, "routine", "agentRoutine")
+	a.logger.Info("agent started", zap.String("version", buildinfo.GetVersion()), zap.Any("routine", agentCtx.Value("routine")))
+	a.cancelFunction = cancelFunc
 	mqtt.CRITICAL = &agentLoggerCritical{a: a}
 	mqtt.ERROR = &agentLoggerError{a: a}
 
@@ -122,7 +125,7 @@ func (a *orbAgent) Start() error {
 		mqtt.DEBUG = &agentLoggerDebug{a: a}
 	}
 
-	if err := a.startBackends(); err != nil {
+	if err := a.startBackends(ctx); err != nil {
 		return err
 	}
 
@@ -137,31 +140,33 @@ func (a *orbAgent) Start() error {
 
 	a.groupRequestSucceeded = make(chan bool, 1)
 	a.policyRequestSucceeded = make(chan bool, 1)
-
-	if err := a.startComms(cloudConfig); err != nil {
+	commsCtx := context.WithValue(agentCtx, "routine", "comms")
+	if err := a.startComms(commsCtx, cloudConfig); err != nil {
 		a.logger.Error("could not restart mqtt client")
 		return err
 	}
 
 	a.hbTicker = time.NewTicker(HeartbeatFreq)
 	a.hbDone = make(chan bool)
-	go a.sendHeartbeats()
+	heartbeatCtx := context.WithValue(agentCtx, "routine", "heartbeat")
+	go a.sendHeartbeats(heartbeatCtx)
 
 	return nil
 }
 
-func (a *orbAgent) Stop() {
-	a.logger.Info("stopping agent")
+func (a *orbAgent) Stop(ctx context.Context) {
+	a.logger.Info("routine call for stop agent", zap.Any("routine", ctx.Value("routine")))
+	defer a.cancelFunction()
 	a.logger.Debug("stopping agent with number of go routines and go calls", zap.Int("goroutines", runtime.NumGoroutine()), zap.Int64("gocalls", runtime.NumCgoCall()))
 	a.hbTicker.Stop()
 	a.hbDone <- true
-	a.sendSingleHeartbeat(time.Now(), fleet.Offline)
+	a.sendSingleHeartbeat(ctx, time.Now(), fleet.Offline) // maybe remove since we have in defer of the heartbeat routine
 	if token := a.client.Unsubscribe(a.rpcFromCoreTopic); token.Wait() && token.Error() != nil {
 		a.logger.Warn("failed to unsubscribe to RPC channel", zap.Error(token.Error()))
 	}
 	a.unsubscribeGroupChannels()
 	for _, be := range a.backends {
-		if err := be.Stop(); err != nil {
+		if err := be.Stop(ctx); err != nil {
 			a.logger.Error("backend error while stopping", zap.Error(err))
 		}
 	}
@@ -171,7 +176,7 @@ func (a *orbAgent) Stop() {
 	defer close(a.groupRequestSucceeded)
 }
 
-func (a *orbAgent) RestartBackend(name string, reason string) error {
+func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason string) error {
 	if !backend.HaveBackend(name) {
 		return errors.New("specified backend does not exist: " + name)
 	}
@@ -183,7 +188,7 @@ func (a *orbAgent) RestartBackend(name string, reason string) error {
 		a.logger.Error("failed to remove policies", zap.String("backend", name), zap.Error(err))
 	}
 	a.logger.Info("resetting backend", zap.String("backend", name))
-	if err := be.FullReset(); err != nil {
+	if err := be.FullReset(ctx); err != nil {
 		a.logger.Error("failed to reset backend", zap.String("backend", name), zap.Error(err))
 	}
 	a.logger.Info("reapplying policies", zap.String("backend", name))
@@ -193,7 +198,7 @@ func (a *orbAgent) RestartBackend(name string, reason string) error {
 	return nil
 }
 
-func (a *orbAgent) restartComms() error {
+func (a *orbAgent) restartComms(ctx context.Context) error {
 	ccm, err := cloud_config.New(a.logger, a.config, a.db)
 	if err != nil {
 		return err
@@ -202,23 +207,23 @@ func (a *orbAgent) restartComms() error {
 	if err != nil {
 		return err
 	}
-	if err := a.startComms(cloudConfig); err != nil {
+	if err := a.startComms(ctx, cloudConfig); err != nil {
 		a.logger.Error("could not restart mqtt client")
 		return err
 	}
 	return nil
 }
 
-func (a *orbAgent) RestartAll(reason string) error {
-	a.logger.Info("restarting comms")
-	err := a.restartComms()
+func (a *orbAgent) RestartAll(ctx context.Context, reason string) error {
+	a.logger.Info("restarting comms", zap.String("reason", reason))
+	err := a.restartComms(ctx)
 	if err != nil {
 		a.logger.Error("failed to restart comms", zap.Error(err))
 	}
 	a.logger.Info("restarting all backends", zap.String("reason", reason))
 	for name := range a.backends {
 		a.logger.Info("restarting backend", zap.String("backend", name), zap.String("reason", reason))
-		err = a.RestartBackend(name, reason)
+		err = a.RestartBackend(ctx, name, reason)
 		if err != nil {
 			a.logger.Error("failed to restart backend", zap.Error(err))
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -157,6 +157,12 @@ func (a *orbAgent) Start(ctx context.Context, cancelFunc context.CancelFunc) err
 func (a *orbAgent) Stop(ctx context.Context) {
 	a.logger.Info("routine call for stop agent", zap.Any("routine", ctx.Value("routine")))
 	defer a.cancelFunction()
+	for name, b := range a.backends {
+		a.logger.Debug("stopping backend", zap.String("backend", name))
+		if err := b.Stop(ctx); err != nil {
+			a.logger.Error("error while stopping the backend", zap.String("backend", name))
+		}
+	}
 	a.logger.Debug("stopping agent with number of go routines and go calls", zap.Int("goroutines", runtime.NumGoroutine()), zap.Int64("gocalls", runtime.NumCgoCall()))
 	a.hbTicker.Stop()
 	a.hbDone <- true

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ns1labs/orb/agent/config"
 	"github.com/ns1labs/orb/agent/policyMgr"
 	"github.com/ns1labs/orb/buildinfo"
-	"github.com/ns1labs/orb/fleet"
 	"go.uber.org/zap"
 	"runtime"
 	"time"
@@ -165,7 +164,6 @@ func (a *orbAgent) Stop(ctx context.Context) {
 	}
 	a.hbTicker.Stop()
 	if a.client != nil && a.client.IsConnected() {
-		a.sendSingleHeartbeat(ctx, time.Now(), fleet.Offline) // maybe remove since we have in defer of the heartbeat routine
 		if token := a.client.Unsubscribe(a.rpcFromCoreTopic); token.Wait() && token.Error() != nil {
 			a.logger.Warn("failed to unsubscribe to RPC channel", zap.Error(token.Error()))
 		}

--- a/agent/backend/backend.go
+++ b/agent/backend/backend.go
@@ -5,6 +5,7 @@
 package backend
 
 import (
+	"context"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/ns1labs/orb/agent/policies"
 	"go.uber.org/zap"
@@ -45,9 +46,9 @@ type Backend interface {
 	Configure(*zap.Logger, policies.PolicyRepo, map[string]string, map[string]interface{}) error
 	SetCommsClient(string, mqtt.Client, string)
 	Version() (string, error)
-	Start() error
-	Stop() error
-	FullReset() error
+	Start(ctx context.Context, cancelFunc context.CancelFunc) error
+	Stop(ctx context.Context) error
+	FullReset(ctx context.Context) error
 
 	GetStartTime() time.Time
 	GetCapabilities() (map[string]interface{}, error)

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -86,6 +86,7 @@ func (a *orbAgent) nameAgentRPCTopics(channelId string) {
 }
 
 func (a *orbAgent) unsubscribeGroupChannels() {
+	a.logger.Debug("calling to unsub group channels")
 	for id, groupInfo := range a.groupsInfos {
 		base := fmt.Sprintf("channels/%s/messages", groupInfo.ChannelID)
 		rpcFromCoreTopic := fmt.Sprintf("%s/%s", base, fleet.RPCFromCoreTopic)

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -58,8 +58,9 @@ func (a *orbAgent) requestReconnection(ctx context.Context, client mqtt.Client, 
 
 	if token := client.Subscribe(a.rpcFromCoreTopic, 1, a.handleRPCFromCore); token.Wait() && token.Error() != nil {
 		a.logger.Error("failed to subscribe to agent control plane RPC topic", zap.String("topic", a.rpcFromCoreTopic), zap.Error(token.Error()))
+		a.logger.Error("critical failure: unable to subscribe to control plane")
 		a.Stop(ctx)
-		a.logger.Fatal("critical failure: unable to subscribe to control plane")
+		return
 	}
 
 	err := a.sendCapabilities()

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -102,10 +102,13 @@ func Run(cmd *cobra.Command, args []string) {
 		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL)
 		select {
 		case <-sigs:
+			logger.Warn("stop signal received stopping agent")
+			a.Stop(rootCtx)
 			cancelFunc()
 		case <-rootCtx.Done():
-			a.Stop(rootCtx)
+			logger.Warn("mainRoutine context cancelled")
 			done <- true
+			return
 		}
 	}()
 


### PR DESCRIPTION
- Added context to all go routines to trace and terminate all of them in a cascade.
- Removed fatal log.
- Added validation in stop method if client is still connected, unsub, heartbeat offline and disconnect. If client is not connected, skips.

This fixes #1619 