### PR TITLE
[FIX] Add sinker to the list of scraped prometheus metrics in docker-compose config

### DIFF
--- a/docker/configs/prometheus.yml
+++ b/docker/configs/prometheus.yml
@@ -6,4 +6,4 @@ scrape_configs:
   - job_name: 'mainflux'
 
     static_configs:
-      - targets: [ 'auth:8189', 'users:8180', 'things:8182', 'fleet:8203', 'sinks:8200', 'policies:8202' ]
+      - targets: [ 'auth:8189', 'users:8180', 'things:8182', 'fleet:8203', 'sinks:8200', 'policies:8202', 'sinker:8201' ]


### PR DESCRIPTION
This PR resolve this task:
https://app.zenhub.com/workspaces/orb--pktvisor-board-61a78386a3b924000fb03cbb/issues/ns1labs/orb/565