### PR TITLE
fix(agent): unsub from all group channels before restarting comms.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -199,6 +199,9 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 }
 
 func (a *orbAgent) restartComms(ctx context.Context) error {
+	if a.client != nil && a.client.IsConnected() {
+		a.unsubscribeGroupChannels()
+	}
 	ccm, err := cloud_config.New(a.logger, a.config, a.db)
 	if err != nil {
 		return err


### PR DESCRIPTION
This fixes #1517 

Signed-off-by: Luiz Pegoraro <luiz.pegoraro@encora.com>