### PR TITLE
Enable Consume Messages async in Fleet

### DIFF
--- a/cmd/sinker/main.go
+++ b/cmd/sinker/main.go
@@ -185,7 +185,7 @@ func main() {
 		Subsystem: "sink",
 		Name:      "message_inbound",
 		Help:      "Number of messages received",
-	}, []string{"method", "agent_id", "subtopic", "channel", "protocol", "created", "trace_id"})
+	}, []string{"method", "agent_id", "subtopic", "channel", "protocol"})
 
 	svc := sinker.New(logger, pubSub, esClient, configRepo, policiesGRPCClient, fleetGRPCClient, sinksGRPCClient, gauge, counter, inputCounter)
 	defer func(svc sinker.Service) {

--- a/python-test/features/steps/control_plane_policies.py
+++ b/python-test/features/steps/control_plane_policies.py
@@ -40,7 +40,7 @@ def create_new_policy(context, kwargs):
 def policy_editing(context, kwargs):
     acceptable_keys = ['name', 'handler_label', 'handler', 'description', 'tap', 'input_type',
                        'host_specification', 'bpf_filter_expression', 'pcap_source', 'only_qname_suffix',
-                       'only_rcode', 'backend_type']
+                       'only_rcode', 'exclude_noerror', 'backend_type']
 
     handler_label = list(context.policy["policy"]["handlers"]["modules"].keys())[0]
 

--- a/sinker/service.go
+++ b/sinker/service.go
@@ -132,9 +132,6 @@ func (svc sinkerService) remoteWriteToPrometheus(tsList prometheus.TSList, owner
 }
 
 func (svc sinkerService) encodeBase64(user string, password string) string {
-	defer func(t time.Time) {
-		svc.logger.Debug("encodeBase64 took", zap.String("execution", time.Since(t).String()))
-	}(time.Now())
 	sEnc := b64.URLEncoding.EncodeToString([]byte(user + ":" + password))
 	return fmt.Sprintf("Basic %s", sEnc)
 }

--- a/sinker/service.go
+++ b/sinker/service.go
@@ -32,7 +32,6 @@ import (
 	"go.opentelemetry.io/otel/metric/global"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -280,8 +279,6 @@ func (svc sinkerService) handleMsgFromAgent(msg messaging.Message) error {
 				"subtopic", msg.Subtopic,
 				"channel", msg.Channel,
 				"protocol", msg.Protocol,
-				"created", strconv.FormatInt(msg.Created, 10),
-				"trace_id", ctx.Value("trace-id").(string),
 			}
 			svc.messageInputCounter.With(labels...).Add(1)
 			svc.logger.Info("message consumption time", zap.String("execution", time.Since(t).String()))


### PR DESCRIPTION
Enable consume messages asynchronously in fleet and add context cancellation in services that consumes messages.