### PR TITLE
fix(orb-ui): #405 fix tag input 

### DIFF
--- a/ui/src/app/shared/components/orb/tag-control/tag-control.component.html
+++ b/ui/src/app/shared/components/orb/tag-control/tag-control.component.html
@@ -30,12 +30,13 @@
           <span *ngIf="required" class="ns1red">*</span>
         </div>
         <div>
-          <input #keyInput
+          <input #keyInput="ngModel"
                  autofocus="true"
                  data-orb-qa-id="input#orb_tag_key"
                  fieldSize="medium"
                  maxlength="64"
-                 id="key"
+                 required
+                 ngxEmptyInput
                  name="key"
                  [(ngModel)]="key"
                  fullWidth="true"
@@ -63,7 +64,7 @@
       <div class="d-flex col-1 align-items-center justify-content-center mx-0 pl-4 px-0"
            style="transform: translateY(14px);">
         <button (click)="onAddTag()"
-                [disabled]="key === ''"
+                [disabled]="keyInput.invalid"
                 data-orb-qa-id="button#addTag"
                 ghost
                 nbButton>

--- a/ui/src/app/shared/directives/empty-input.directive.ts
+++ b/ui/src/app/shared/directives/empty-input.directive.ts
@@ -1,0 +1,23 @@
+import {AbstractControl, NG_VALIDATORS, ValidationErrors, Validator, ValidatorFn} from '@angular/forms';
+import {Directive} from '@angular/core';
+
+@Directive({
+  selector: '[ngxEmptyInput]',
+  providers: [{provide: NG_VALIDATORS,
+    useExisting: EmptyInputDirective,
+    multi: true}],
+})
+export class EmptyInputDirective implements Validator {
+  validate(control: AbstractControl): ValidationErrors | null {
+    return emptyInputValidator()(control);
+  }
+}
+
+export function emptyInputValidator(): ValidatorFn {
+  return (control): ValidationErrors | null => {
+    const {value} = control;
+    if (!value) return null;
+    const trimmed = control.value.trim();
+    return trimmed === '' ? {emptyInput: {value: control.value}} : null;
+  };
+}

--- a/ui/src/app/shared/shared.module.ts
+++ b/ui/src/app/shared/shared.module.ts
@@ -61,6 +61,7 @@ import { MessageValuePipe } from './pipes/message-value.pipe';
 import { PrettyYamlPipe } from './pipes/pretty-yaml.pipe';
 import { ToMillisecsPipe } from './pipes/time.pipe';
 import { PollControlComponent } from './components/poll-control/poll-control.component';
+import {EmptyInputDirective} from 'app/shared/directives/empty-input.directive';
 
 @NgModule({
   imports: [
@@ -126,6 +127,7 @@ import { PollControlComponent } from './components/poll-control/poll-control.com
     SortPipe,
     FilterComponent,
     PollControlComponent,
+    EmptyInputDirective,
   ],
   exports: [
     ThemeModule,
@@ -160,6 +162,7 @@ import { PollControlComponent } from './components/poll-control/poll-control.com
     SortPipe,
     FilterComponent,
     PollControlComponent,
+    EmptyInputDirective,
   ],
   providers: [
     MessageValuePipe,


### PR DESCRIPTION
* add validator to tag key input, invalidating the 'add' tag button when tag key is empty or blank spaces.