### PR TITLE
feat(agent): register backends when configuration is enabled

### DIFF
--- a/cmd/agent/agent.example.yaml
+++ b/cmd/agent/agent.example.yaml
@@ -39,6 +39,10 @@ orb:
 #    file: "/usr/local/orb/orb-agent.db"
   backends:
     pktvisor:
+      enabled: true
       binary: "/usr/local/sbin/pktvisord"
       # this example assumes the file is saved as agent.yaml. If your file has another name, you must replace it with the proper name
       config_file: "/usr/local/orb/etc/agent.yaml"
+    cloudprober:
+      enabled: false
+      binary: "/usr/local/sbin/pktvisord"


### PR DESCRIPTION
Default is pktvisor, and adapt config file to contain this structure:

```yaml
  backends:
    pktvisor:
      enabled: true
      binary: "/usr/local/sbin/pktvisord"
      # this example assumes the file is saved as agent.yaml. If your file has another name, you must replace it with the proper name
      config_file: "/usr/local/orb/etc/agent.yaml"
    cloudprober:
      enabled: false
      binary: "/usr/local/sbin/cloudprober"

```