### PR TITLE
orb-agent improvements on backend error

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -117,7 +117,8 @@ func (a *orbAgent) startBackends(agentCtx context.Context) error {
 		}
 		a.backends[name] = be
 		a.backendState[name] = &backend.State{
-			Status: backend.Unknown,
+			Status:        backend.Unknown,
+			LastRestartTS: time.Unix(0, 0),
 		}
 	}
 	return nil

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -118,7 +118,7 @@ func (a *orbAgent) startBackends(agentCtx context.Context) error {
 		a.backends[name] = be
 		a.backendState[name] = &backend.State{
 			Status:        backend.Unknown,
-			LastRestartTS: time.Unix(0, 0),
+			LastRestartTS: time.Now(),
 		}
 	}
 	return nil

--- a/agent/backend/backend.go
+++ b/agent/backend/backend.go
@@ -13,16 +13,16 @@ import (
 )
 
 const (
-	Unknown BackendState = iota
+	Unknown RunningStatus = iota
 	Running
 	BackendError
 	AgentError
 	Offline
 )
 
-type BackendState int
+type RunningStatus int
 
-var backendStateMap = [...]string{
+var runningStatusMap = [...]string{
 	"unknown",
 	"running",
 	"backend_error",
@@ -30,7 +30,7 @@ var backendStateMap = [...]string{
 	"offline",
 }
 
-var backendStateRevMap = map[string]BackendState{
+var runningStatusRevMap = map[string]RunningStatus{
 	"unknown":       Unknown,
 	"running":       Running,
 	"backend_error": BackendError,
@@ -38,8 +38,16 @@ var backendStateRevMap = map[string]BackendState{
 	"offline":       Offline,
 }
 
-func (s BackendState) String() string {
-	return backendStateMap[s]
+type State struct {
+	Status            RunningStatus
+	RestartCount      int64
+	LastError         string
+	LastRestartTS     time.Time
+	LastRestartReason string
+}
+
+func (s RunningStatus) String() string {
+	return runningStatusMap[s]
 }
 
 type Backend interface {
@@ -52,7 +60,7 @@ type Backend interface {
 
 	GetStartTime() time.Time
 	GetCapabilities() (map[string]interface{}, error)
-	GetState() (BackendState, string, error)
+	GetRunningStatus() (RunningStatus, string, error)
 
 	ApplyPolicy(data policies.PolicyData, updatePolicy bool) error
 	RemovePolicy(data policies.PolicyData) error

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -265,14 +265,14 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 	if len(p.configFile) > 0 {
 		pvOptions = append(pvOptions, "--config", p.configFile)
 	}
-	
-        // the macros should be properly configured to enable crashpad
+
+	// the macros should be properly configured to enable crashpad
 	// pvOptions = append(pvOptions, "--cp-token", PKTVISOR_CP_TOKEN)
 	// pvOptions = append(pvOptions, "--cp-url", PKTVISOR_CP_URL)
 	// pvOptions = append(pvOptions, "--cp-path", PKTVISOR_CP_PATH)
 	// pvOptions = append(pvOptions, "--default-geo-city", "/geo-db/city.mmdb")
 	// pvOptions = append(pvOptions, "--default-geo-asn", "/geo-db/asn.mmdb")
-	
+
 	p.logger.Info("pktvisor startup", zap.Strings("arguments", pvOptions))
 
 	p.proc = cmd.NewCmdOptions(cmd.Options{
@@ -405,16 +405,19 @@ func (p *pktvisorBackend) scrapeDefault() error {
 			Payload:       batchPayload,
 		}
 
-		body, err := json.Marshal(rpc)
+		// ###### DO NOT MERGE ###########
+		_, err = json.Marshal(rpc)
 		if err != nil {
 			p.logger.Error("error marshalling metric rpc payload", zap.Error(err))
 			return
 		}
 
-		if token := p.mqttClient.Publish(p.metricsTopic, 1, false, body); token.Wait() && token.Error() != nil {
-			p.logger.Error("error sending metrics RPC", zap.String("topic", p.metricsTopic), zap.Error(token.Error()))
-			return
-		}
+		p.logger.Info("FAKE METRIC SEND")
+		//if token := p.mqttClient.Publish(p.metricsTopic, 1, false, body); token.Wait() && token.Error() != nil {
+		//	p.logger.Error("error sending metrics RPC", zap.String("topic", p.metricsTopic), zap.Error(token.Error()))
+		//	return
+		//}
+		// ###### DO NO MERGE ##########
 		p.logger.Info("scraped and published metrics", zap.String("topic", p.metricsTopic), zap.Int("payload_size_b", totalSize), zap.Int("batch_count", len(batchPayload)))
 
 	})

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -5,13 +5,9 @@
 package pktvisor
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net/http"
 	"os/exec"
 	"strings"
@@ -22,13 +18,9 @@ import (
 	"github.com/go-co-op/gocron"
 	"github.com/ns1labs/orb/agent/backend"
 	"github.com/ns1labs/orb/agent/config"
-	"github.com/ns1labs/orb/agent/otel/otlpmqttexporter"
-	"github.com/ns1labs/orb/agent/otel/pktvisorreceiver"
 	"github.com/ns1labs/orb/agent/policies"
-	"github.com/ns1labs/orb/fleet"
 	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
-	"gopkg.in/yaml.v3"
 )
 
 var _ backend.Backend = (*pktvisorBackend)(nil)
@@ -39,10 +31,18 @@ const (
 	ReadinessTimeout    = 10
 	ApplyPolicyTimeout  = 10
 	RemovePolicyTimeout = 15
-	VersionTimeout      = 5
+	VersionTimeout      = 2 // also used for readiness check
 	ScrapeTimeout       = 5
 	TapsTimeout         = 5
 )
+
+// AppInfo represents server application information
+type AppInfo struct {
+	App struct {
+		Version   string  `json:"version"`
+		UpTimeMin float64 `json:"up_time_min"`
+	} `json:"app"`
+}
 
 type pktvisorBackend struct {
 	logger          *zap.Logger
@@ -85,161 +85,29 @@ func (p *pktvisorBackend) SetCommsClient(agentID string, client mqtt.Client, bas
 	p.otlpMetricsTopic = fmt.Sprintf("%s/m/%c", otelMetricsTopic, agentID[0])
 }
 
-func (p *pktvisorBackend) GetState() (backend.BackendState, string, error) {
-	_, err := p.checkAlive()
-	if err != nil {
-		return backend.Unknown, "", err
+func (p *pktvisorBackend) GetRunningStatus() (backend.RunningStatus, string, error) {
+	// first check process status
+	runningStatus, errMsg, err := p.getProcRunningStatus()
+	// if it's not running, we're done
+	if runningStatus != backend.Running {
+		return runningStatus, errMsg, err
 	}
-	return backend.Running, "", nil
-}
-
-// AppMetrics represents server application information
-type AppMetrics struct {
-	App struct {
-		Version   string  `json:"version"`
-		UpTimeMin float64 `json:"up_time_min"`
-	} `json:"app"`
-}
-
-// note this needs to be stateless because it is called for multiple go routines
-func (p *pktvisorBackend) request(url string, payload interface{}, method string, body io.Reader, contentType string, timeout int32) error {
-	client := http.Client{
-		Timeout: time.Second * time.Duration(timeout),
+	// if it's running, check REST API availability too
+	_, aiErr := p.getAppInfo()
+	if aiErr != nil {
+		// process is running, but REST API is not accessible
+		return backend.BackendError, "process running, REST API unavailable", aiErr
 	}
-
-	alive, err := p.checkAlive()
-	if !alive {
-		return err
-	}
-
-	URL := fmt.Sprintf("%s://%s:%s/api/v1/%s", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIPort, url)
-
-	req, err := http.NewRequest(method, URL, body)
-	if err != nil {
-		p.logger.Error("received error from payload", zap.Error(err))
-		return err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-	res, getErr := client.Do(req)
-
-	if getErr != nil {
-		p.logger.Error("received error from payload", zap.Error(getErr))
-		return getErr
-	}
-
-	if (res.StatusCode < 200) || (res.StatusCode > 299) {
-		body, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			return errors.New(fmt.Sprintf("non 2xx HTTP error code from pktvisord, no or invalid body: %d", res.StatusCode))
-		}
-		if len(body) == 0 {
-			return errors.New(fmt.Sprintf("%d empty body", res.StatusCode))
-		} else if body[0] == '{' {
-			var jsonBody map[string]interface{}
-			err := json.Unmarshal(body, &jsonBody)
-			if err == nil {
-				if errMsg, ok := jsonBody["error"]; ok {
-					return errors.New(fmt.Sprintf("%d %s", res.StatusCode, errMsg))
-				}
-			}
-		}
-	}
-
-	if res.Body != nil {
-		err = json.NewDecoder(res.Body).Decode(&payload)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (p *pktvisorBackend) checkAlive() (bool, error) {
-	status := p.proc.Status()
-
-	if status.Error != nil {
-		p.logger.Error("pktvisor process error", zap.Error(status.Error))
-		return false, status.Error
-	}
-
-	if status.Complete {
-		err := p.proc.Stop()
-		if err != nil {
-			p.logger.Error("proc.Stop error", zap.Error(err))
-		}
-		return false, errors.New("pktvisor process ended")
-	}
-
-	if status.StopTs > 0 {
-		p.logger.Info("pktvisor process stopped")
-		return false, errors.New("pktvisor process ended")
-	}
-
-	return true, nil
-}
-
-func (p *pktvisorBackend) ApplyPolicy(data policies.PolicyData, updatePolicy bool) error {
-
-	if updatePolicy {
-		// To update a policy it's necessary first remove it and then apply a new version
-		err := p.RemovePolicy(data)
-		if err != nil {
-			p.logger.Warn("policy failed to remove", zap.String("policy_id", data.ID), zap.String("policy_name", data.Name), zap.Error(err))
-		}
-	}
-
-	p.logger.Debug("pktvisor policy apply", zap.String("policy_id", data.ID), zap.Any("data", data.Data))
-
-	fullPolicy := map[string]interface{}{
-		"version": "1.0",
-		"visor": map[string]interface{}{
-			"policies": map[string]interface{}{
-				data.Name: data.Data,
-			},
-		},
-	}
-
-	policyYaml, err := yaml.Marshal(fullPolicy)
-	if err != nil {
-		p.logger.Warn("yaml policy marshal failure", zap.String("policy_id", data.ID), zap.Any("policy", fullPolicy))
-		return err
-	}
-
-	var resp map[string]interface{}
-	err = p.request("policies", &resp, http.MethodPost, bytes.NewBuffer(policyYaml), "application/x-yaml", ApplyPolicyTimeout)
-	if err != nil {
-		p.logger.Warn("yaml policy application failure", zap.String("policy_id", data.ID), zap.ByteString("policy", policyYaml))
-		return err
-	}
-
-	return nil
-
-}
-
-func (p *pktvisorBackend) RemovePolicy(data policies.PolicyData) error {
-	var resp interface{}
-	err := p.request(fmt.Sprintf("policies/%s", data.Name), &resp, http.MethodDelete, http.NoBody, "application/json", RemovePolicyTimeout)
-	if err != nil {
-		p.logger.Error("received error", zap.Error(err))
-		return err
-	}
-	return nil
+	return runningStatus, "", nil
 }
 
 func (p *pktvisorBackend) Version() (string, error) {
-	var appMetrics AppMetrics
-	err := p.request("metrics/app", &appMetrics, http.MethodGet, http.NoBody, "application/json", VersionTimeout)
+	appInfo, err := p.getAppInfo()
 	if err != nil {
 		return "", err
 	}
-	p.pktvisorVersion = appMetrics.App.Version
-	return appMetrics.App.Version, nil
-}
-
-func (p *pktvisorBackend) Write(payload []byte) (n int, err error) {
-	p.logger.Info("pktvisord", zap.ByteString("log", payload))
-	return len(payload), nil
+	p.pktvisorVersion = appInfo.App.Version
+	return appInfo.App.Version, nil
 }
 
 func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
@@ -325,7 +193,7 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 
 	var readinessError error
 	for backoff := 0; backoff < ReadinessBackoff; backoff++ {
-		var appMetrics AppMetrics
+		var appMetrics AppInfo
 		readinessError = p.request("metrics/app", &appMetrics, http.MethodGet, http.NoBody, "application/json", ReadinessTimeout)
 		if readinessError == nil {
 			p.logger.Info("pktvisor readiness ok, got version ", zap.String("pktvisor_version", appMetrics.App.Version))
@@ -357,131 +225,6 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 	}
 
 	return nil
-}
-
-func (p *pktvisorBackend) scrapeDefault() error {
-	// scrape all policy json output with one call every minute.
-	// TODO support policies with custom bucket times
-	job, err := p.scraper.Every(1).Minute().WaitForSchedule().Do(func() {
-		metrics, err := p.scrapeMetrics(1)
-		if err != nil {
-			p.logger.Error("scrape failed", zap.Error(err))
-			return
-		}
-		if len(metrics) == 0 {
-			p.logger.Warn("scrape: no policies found, skipping")
-			return
-		}
-
-		var batchPayload []fleet.AgentMetricsRPCPayload
-		totalSize := 0
-		for pName, pMetrics := range metrics {
-			data, err := p.policyRepo.GetByName(pName)
-			if err != nil {
-				p.logger.Warn("skipping pktvisor policy not managed by orb", zap.String("policy", pName), zap.String("error_message", err.Error()))
-				continue
-			}
-			payloadData, err := json.Marshal(pMetrics)
-			if err != nil {
-				p.logger.Error("error marshalling scraped metric json", zap.String("policy", pName), zap.Error(err))
-				continue
-			}
-			metricPayload := fleet.AgentMetricsRPCPayload{
-				PolicyID:   data.ID,
-				PolicyName: data.Name,
-				Datasets:   data.GetDatasetIDs(),
-				Format:     "json",
-				BEVersion:  p.pktvisorVersion,
-				Data:       payloadData,
-			}
-			batchPayload = append(batchPayload, metricPayload)
-			totalSize += len(payloadData)
-			p.logger.Info("scraped metrics for policy", zap.String("policy", pName), zap.String("policy_id", data.ID), zap.Int("payload_size_b", len(payloadData)))
-		}
-
-		rpc := fleet.AgentMetricsRPC{
-			SchemaVersion: fleet.CurrentRPCSchemaVersion,
-			Func:          fleet.AgentMetricsRPCFunc,
-			Payload:       batchPayload,
-		}
-
-		// ###### DO NOT MERGE ###########
-		_, err = json.Marshal(rpc)
-		if err != nil {
-			p.logger.Error("error marshalling metric rpc payload", zap.Error(err))
-			return
-		}
-
-		p.logger.Info("FAKE METRIC SEND")
-		//if token := p.mqttClient.Publish(p.metricsTopic, 1, false, body); token.Wait() && token.Error() != nil {
-		//	p.logger.Error("error sending metrics RPC", zap.String("topic", p.metricsTopic), zap.Error(token.Error()))
-		//	return
-		//}
-		// ###### DO NO MERGE ##########
-		p.logger.Info("scraped and published metrics", zap.String("topic", p.metricsTopic), zap.Int("payload_size_b", totalSize), zap.Int("batch_count", len(batchPayload)))
-
-	})
-
-	if err != nil {
-		return err
-	}
-
-	job.SingletonMode()
-	return nil
-}
-
-func (p *pktvisorBackend) scrapeOpenTelemetry(ctx context.Context) {
-	go func() {
-		startExpCtx, cancelFunc := context.WithCancel(ctx)
-		var ok bool
-		var err error
-		for i := 1; i < 10; i++ {
-			select {
-			case <-startExpCtx.Done():
-				return
-			default:
-				if p.mqttClient != nil {
-					var errStartExp error
-					p.exporter, errStartExp = p.createOtlpMqttExporter(ctx)
-					if errStartExp != nil {
-						p.logger.Error("failed to create a exporter", zap.Error(err))
-						return
-					}
-
-					p.receiver, err = createReceiver(ctx, p.exporter, p.logger)
-					if err != nil {
-						p.logger.Error("failed to create a receiver", zap.Error(err))
-						return
-					}
-
-					err = p.exporter.Start(ctx, nil)
-					if err != nil {
-						p.logger.Error("otel mqtt exporter startup error", zap.Error(err))
-						return
-					}
-
-					err = p.receiver.Start(ctx, nil)
-					if err != nil {
-						p.logger.Error("otel receiver startup error", zap.Error(err))
-						return
-					}
-
-					ok = true
-					return
-				} else {
-					p.logger.Info("waiting until mqtt client is connected", zap.String("wait time", (time.Duration(i)*time.Second).String()))
-					time.Sleep(time.Duration(i) * time.Second)
-					continue
-				}
-			}
-		}
-		if !ok {
-			p.logger.Error("mqtt did not established a connection, stopping agent")
-			p.Stop(startExpCtx)
-		}
-		cancelFunc()
-		return
-	}()
 }
 
 func (p *pktvisorBackend) Stop(ctx context.Context) error {
@@ -535,15 +278,6 @@ func (p *pktvisorBackend) Configure(logger *zap.Logger, repo policies.PolicyRepo
 	return nil
 }
 
-func (p *pktvisorBackend) scrapeMetrics(period uint) (map[string]interface{}, error) {
-	var metrics map[string]interface{}
-	err := p.request(fmt.Sprintf("policies/__all/metrics/bucket/%d", period), &metrics, http.MethodGet, http.NoBody, "application/json", ScrapeTimeout)
-	if err != nil {
-		return nil, err
-	}
-	return metrics, nil
-}
-
 func (p *pktvisorBackend) GetCapabilities() (map[string]interface{}, error) {
 	var taps interface{}
 	err := p.request("taps", &taps, http.MethodGet, http.NoBody, "application/json", TapsTimeout)
@@ -555,53 +289,10 @@ func (p *pktvisorBackend) GetCapabilities() (map[string]interface{}, error) {
 	return jsonBody, nil
 }
 
-func Register() bool {
-	backend.Register("pktvisor", &pktvisorBackend{
-		adminAPIProtocol: "http",
-	})
-	return true
-}
-
-func (p *pktvisorBackend) createOtlpMqttExporter(ctx context.Context) (component.MetricsExporter, error) {
-
-	if p.mqttClient != nil {
-		cfg := otlpmqttexporter.CreateConfigClient(p.mqttClient, p.otlpMetricsTopic, p.pktvisorVersion)
-		set := otlpmqttexporter.CreateDefaultSettings(p.logger)
-		// Create the OTLP metrics exporter that'll receive and verify the metrics produced.
-		exporter, err := otlpmqttexporter.CreateMetricsExporter(ctx, set, cfg)
-		if err != nil {
-			return nil, err
-		}
-		return exporter, nil
-	} else {
-		cfg := otlpmqttexporter.CreateConfig(p.mqttConfig.Address, p.mqttConfig.Id, p.mqttConfig.Key,
-			p.mqttConfig.ChannelID, p.pktvisorVersion, p.otlpMetricsTopic)
-		set := otlpmqttexporter.CreateDefaultSettings(p.logger)
-		// Create the OTLP metrics exporter that'll receive and verify the metrics produced.
-		exporter, err := otlpmqttexporter.CreateMetricsExporter(ctx, set, cfg)
-		if err != nil {
-			return nil, err
-		}
-		return exporter, nil
-	}
-
-}
-
-func createReceiver(ctx context.Context, exporter component.MetricsExporter, logger *zap.Logger) (component.MetricsReceiver, error) {
-	set := pktvisorreceiver.CreateDefaultSettings(logger)
-	cfg := pktvisorreceiver.CreateDefaultConfig()
-	// Create the Prometheus receiver and pass in the previously created Prometheus exporter.
-	receiver, err := pktvisorreceiver.CreateMetricsReceiver(ctx, set, cfg, exporter)
-	if err != nil {
-		return nil, err
-	}
-	return receiver, nil
-}
-
 func (p *pktvisorBackend) FullReset(ctx context.Context) error {
 
 	// force a stop, which stops scrape as well. if proc is dead, it no ops.
-	if state, _, _ := p.GetState(); state == backend.Running {
+	if state, _, _ := p.getProcRunningStatus(); state == backend.Running {
 		if err := p.Stop(ctx); err != nil {
 			p.logger.Error("failed to stop backend on restart procedure", zap.Error(err))
 			return err
@@ -616,4 +307,11 @@ func (p *pktvisorBackend) FullReset(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func Register() bool {
+	backend.Register("pktvisor", &pktvisorBackend{
+		adminAPIProtocol: "http",
+	})
+	return true
 }

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -31,7 +31,7 @@ const (
 	ReadinessTimeout    = 10
 	ApplyPolicyTimeout  = 10
 	RemovePolicyTimeout = 15
-	VersionTimeout      = 2 // also used for readiness check
+	VersionTimeout      = 2
 	ScrapeTimeout       = 5
 	TapsTimeout         = 5
 )

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -30,7 +30,7 @@ const (
 	ReadinessBackoff    = 10
 	ReadinessTimeout    = 10
 	ApplyPolicyTimeout  = 10
-	RemovePolicyTimeout = 15
+	RemovePolicyTimeout = 20
 	VersionTimeout      = 2
 	ScrapeTimeout       = 5
 	TapsTimeout         = 5

--- a/agent/backend/pktvisor/policy.go
+++ b/agent/backend/pktvisor/policy.go
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package pktvisor
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/ns1labs/orb/agent/policies"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+	"net/http"
+)
+
+func (p *pktvisorBackend) ApplyPolicy(data policies.PolicyData, updatePolicy bool) error {
+
+	if updatePolicy {
+		// To update a policy it's necessary first remove it and then apply a new version
+		err := p.RemovePolicy(data)
+		if err != nil {
+			p.logger.Warn("policy failed to remove", zap.String("policy_id", data.ID), zap.String("policy_name", data.Name), zap.Error(err))
+		}
+	}
+
+	p.logger.Debug("pktvisor policy apply", zap.String("policy_id", data.ID), zap.Any("data", data.Data))
+
+	fullPolicy := map[string]interface{}{
+		"version": "1.0",
+		"visor": map[string]interface{}{
+			"policies": map[string]interface{}{
+				data.Name: data.Data,
+			},
+		},
+	}
+
+	policyYaml, err := yaml.Marshal(fullPolicy)
+	if err != nil {
+		p.logger.Warn("yaml policy marshal failure", zap.String("policy_id", data.ID), zap.Any("policy", fullPolicy))
+		return err
+	}
+
+	var resp map[string]interface{}
+	err = p.request("policies", &resp, http.MethodPost, bytes.NewBuffer(policyYaml), "application/x-yaml", ApplyPolicyTimeout)
+	if err != nil {
+		p.logger.Warn("yaml policy application failure", zap.String("policy_id", data.ID), zap.ByteString("policy", policyYaml))
+		return err
+	}
+
+	return nil
+
+}
+
+func (p *pktvisorBackend) RemovePolicy(data policies.PolicyData) error {
+	var resp interface{}
+	err := p.request(fmt.Sprintf("policies/%s", data.Name), &resp, http.MethodDelete, http.NoBody, "application/json", RemovePolicyTimeout)
+	if err != nil {
+		p.logger.Error("received error", zap.Error(err))
+		return err
+	}
+	return nil
+}

--- a/agent/backend/pktvisor/policy.go
+++ b/agent/backend/pktvisor/policy.go
@@ -52,10 +52,10 @@ func (p *pktvisorBackend) ApplyPolicy(data policies.PolicyData, updatePolicy boo
 }
 
 func (p *pktvisorBackend) RemovePolicy(data policies.PolicyData) error {
+	p.logger.Debug("pktvisor policy remove", zap.String("policy_id", data.ID))
 	var resp interface{}
 	err := p.request(fmt.Sprintf("policies/%s", data.Name), &resp, http.MethodDelete, http.NoBody, "application/json", RemovePolicyTimeout)
 	if err != nil {
-		p.logger.Error("received error", zap.Error(err))
 		return err
 	}
 	return nil

--- a/agent/backend/pktvisor/scrape.go
+++ b/agent/backend/pktvisor/scrape.go
@@ -114,19 +114,17 @@ func (p *pktvisorBackend) scrapeDefault() error {
 			Payload:       batchPayload,
 		}
 
-		// ###### DO NOT MERGE ###########
-		_, err = json.Marshal(rpc)
+		body, err := json.Marshal(rpc)
 		if err != nil {
 			p.logger.Error("error marshalling metric rpc payload", zap.Error(err))
 			return
 		}
 
-		p.logger.Info("FAKE METRIC SEND")
-		//if token := p.mqttClient.Publish(p.metricsTopic, 1, false, body); token.Wait() && token.Error() != nil {
-		//	p.logger.Error("error sending metrics RPC", zap.String("topic", p.metricsTopic), zap.Error(token.Error()))
-		//	return
-		//}
-		// ###### DO NO MERGE ##########
+		if token := p.mqttClient.Publish(p.metricsTopic, 1, false, body); token.Wait() && token.Error() != nil {
+			p.logger.Error("error sending metrics RPC", zap.String("topic", p.metricsTopic), zap.Error(token.Error()))
+			return
+		}
+
 		p.logger.Info("scraped and published metrics", zap.String("topic", p.metricsTopic), zap.Int("payload_size_b", totalSize), zap.Int("batch_count", len(batchPayload)))
 
 	})

--- a/agent/backend/pktvisor/scrape.go
+++ b/agent/backend/pktvisor/scrape.go
@@ -1,0 +1,188 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package pktvisor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/ns1labs/orb/agent/otel/otlpmqttexporter"
+	"github.com/ns1labs/orb/agent/otel/pktvisorreceiver"
+	"github.com/ns1labs/orb/fleet"
+	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
+	"net/http"
+	"time"
+)
+
+func (p *pktvisorBackend) scrapeMetrics(period uint) (map[string]interface{}, error) {
+	var metrics map[string]interface{}
+	err := p.request(fmt.Sprintf("policies/__all/metrics/bucket/%d", period), &metrics, http.MethodGet, http.NoBody, "application/json", ScrapeTimeout)
+	if err != nil {
+		return nil, err
+	}
+	return metrics, nil
+}
+
+func (p *pktvisorBackend) createOtlpMqttExporter(ctx context.Context) (component.MetricsExporter, error) {
+
+	if p.mqttClient != nil {
+		cfg := otlpmqttexporter.CreateConfigClient(p.mqttClient, p.otlpMetricsTopic, p.pktvisorVersion)
+		set := otlpmqttexporter.CreateDefaultSettings(p.logger)
+		// Create the OTLP metrics exporter that'll receive and verify the metrics produced.
+		exporter, err := otlpmqttexporter.CreateMetricsExporter(ctx, set, cfg)
+		if err != nil {
+			return nil, err
+		}
+		return exporter, nil
+	} else {
+		cfg := otlpmqttexporter.CreateConfig(p.mqttConfig.Address, p.mqttConfig.Id, p.mqttConfig.Key,
+			p.mqttConfig.ChannelID, p.pktvisorVersion, p.otlpMetricsTopic)
+		set := otlpmqttexporter.CreateDefaultSettings(p.logger)
+		// Create the OTLP metrics exporter that'll receive and verify the metrics produced.
+		exporter, err := otlpmqttexporter.CreateMetricsExporter(ctx, set, cfg)
+		if err != nil {
+			return nil, err
+		}
+		return exporter, nil
+	}
+
+}
+
+func createReceiver(ctx context.Context, exporter component.MetricsExporter, logger *zap.Logger) (component.MetricsReceiver, error) {
+	set := pktvisorreceiver.CreateDefaultSettings(logger)
+	cfg := pktvisorreceiver.CreateDefaultConfig()
+	// Create the Prometheus receiver and pass in the previously created Prometheus exporter.
+	receiver, err := pktvisorreceiver.CreateMetricsReceiver(ctx, set, cfg, exporter)
+	if err != nil {
+		return nil, err
+	}
+	return receiver, nil
+}
+
+func (p *pktvisorBackend) scrapeDefault() error {
+	// scrape all policy json output with one call every minute.
+	// TODO support policies with custom bucket times
+	job, err := p.scraper.Every(1).Minute().WaitForSchedule().Do(func() {
+		metrics, err := p.scrapeMetrics(1)
+		if err != nil {
+			p.logger.Error("scrape failed", zap.Error(err))
+			return
+		}
+		if len(metrics) == 0 {
+			p.logger.Warn("scrape: no policies found, skipping")
+			return
+		}
+
+		var batchPayload []fleet.AgentMetricsRPCPayload
+		totalSize := 0
+		for pName, pMetrics := range metrics {
+			data, err := p.policyRepo.GetByName(pName)
+			if err != nil {
+				p.logger.Warn("skipping pktvisor policy not managed by orb", zap.String("policy", pName), zap.String("error_message", err.Error()))
+				continue
+			}
+			payloadData, err := json.Marshal(pMetrics)
+			if err != nil {
+				p.logger.Error("error marshalling scraped metric json", zap.String("policy", pName), zap.Error(err))
+				continue
+			}
+			metricPayload := fleet.AgentMetricsRPCPayload{
+				PolicyID:   data.ID,
+				PolicyName: data.Name,
+				Datasets:   data.GetDatasetIDs(),
+				Format:     "json",
+				BEVersion:  p.pktvisorVersion,
+				Data:       payloadData,
+			}
+			batchPayload = append(batchPayload, metricPayload)
+			totalSize += len(payloadData)
+			p.logger.Info("scraped metrics for policy", zap.String("policy", pName), zap.String("policy_id", data.ID), zap.Int("payload_size_b", len(payloadData)))
+		}
+
+		rpc := fleet.AgentMetricsRPC{
+			SchemaVersion: fleet.CurrentRPCSchemaVersion,
+			Func:          fleet.AgentMetricsRPCFunc,
+			Payload:       batchPayload,
+		}
+
+		// ###### DO NOT MERGE ###########
+		_, err = json.Marshal(rpc)
+		if err != nil {
+			p.logger.Error("error marshalling metric rpc payload", zap.Error(err))
+			return
+		}
+
+		p.logger.Info("FAKE METRIC SEND")
+		//if token := p.mqttClient.Publish(p.metricsTopic, 1, false, body); token.Wait() && token.Error() != nil {
+		//	p.logger.Error("error sending metrics RPC", zap.String("topic", p.metricsTopic), zap.Error(token.Error()))
+		//	return
+		//}
+		// ###### DO NO MERGE ##########
+		p.logger.Info("scraped and published metrics", zap.String("topic", p.metricsTopic), zap.Int("payload_size_b", totalSize), zap.Int("batch_count", len(batchPayload)))
+
+	})
+
+	if err != nil {
+		return err
+	}
+
+	job.SingletonMode()
+	return nil
+}
+
+func (p *pktvisorBackend) scrapeOpenTelemetry(ctx context.Context) {
+	go func() {
+		startExpCtx, cancelFunc := context.WithCancel(ctx)
+		var ok bool
+		var err error
+		for i := 1; i < 10; i++ {
+			select {
+			case <-startExpCtx.Done():
+				return
+			default:
+				if p.mqttClient != nil {
+					var errStartExp error
+					p.exporter, errStartExp = p.createOtlpMqttExporter(ctx)
+					if errStartExp != nil {
+						p.logger.Error("failed to create a exporter", zap.Error(err))
+						return
+					}
+
+					p.receiver, err = createReceiver(ctx, p.exporter, p.logger)
+					if err != nil {
+						p.logger.Error("failed to create a receiver", zap.Error(err))
+						return
+					}
+
+					err = p.exporter.Start(ctx, nil)
+					if err != nil {
+						p.logger.Error("otel mqtt exporter startup error", zap.Error(err))
+						return
+					}
+
+					err = p.receiver.Start(ctx, nil)
+					if err != nil {
+						p.logger.Error("otel receiver startup error", zap.Error(err))
+						return
+					}
+
+					ok = true
+					return
+				} else {
+					p.logger.Info("waiting until mqtt client is connected", zap.String("wait time", (time.Duration(i)*time.Second).String()))
+					time.Sleep(time.Duration(i) * time.Second)
+					continue
+				}
+			}
+		}
+		if !ok {
+			p.logger.Error("mqtt did not established a connection, stopping agent")
+			p.Stop(startExpCtx)
+		}
+		cancelFunc()
+		return
+	}()
+}

--- a/agent/backend/pktvisor/utils.go
+++ b/agent/backend/pktvisor/utils.go
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package pktvisor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/ns1labs/orb/agent/backend"
+	"go.uber.org/zap"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+// note this needs to be stateless because it is called for multiple go routines
+func (p *pktvisorBackend) request(url string, payload interface{}, method string, body io.Reader, contentType string, timeout int32) error {
+	client := http.Client{
+		Timeout: time.Second * time.Duration(timeout),
+	}
+
+	status, _, err := p.getProcRunningStatus()
+	if status != backend.Running {
+		p.logger.Warn("ignoring pktvisor request because process is not running or is unresponsive", zap.String("url", url), zap.String("method", method), zap.Error(err))
+		return err
+	}
+
+	URL := fmt.Sprintf("%s://%s:%s/api/v1/%s", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIPort, url)
+
+	req, err := http.NewRequest(method, URL, body)
+	if err != nil {
+		p.logger.Error("received error from payload", zap.Error(err))
+		return err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	res, getErr := client.Do(req)
+
+	if getErr != nil {
+		p.logger.Error("received error from payload", zap.Error(getErr))
+		return getErr
+	}
+
+	if (res.StatusCode < 200) || (res.StatusCode > 299) {
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return errors.New(fmt.Sprintf("non 2xx HTTP error code from pktvisord, no or invalid body: %d", res.StatusCode))
+		}
+		if len(body) == 0 {
+			return errors.New(fmt.Sprintf("%d empty body", res.StatusCode))
+		} else if body[0] == '{' {
+			var jsonBody map[string]interface{}
+			err := json.Unmarshal(body, &jsonBody)
+			if err == nil {
+				if errMsg, ok := jsonBody["error"]; ok {
+					return errors.New(fmt.Sprintf("%d %s", res.StatusCode, errMsg))
+				}
+			}
+		}
+	}
+
+	if res.Body != nil {
+		err = json.NewDecoder(res.Body).Decode(&payload)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *pktvisorBackend) getProcRunningStatus() (backend.RunningStatus, string, error) {
+	status := p.proc.Status()
+
+	if status.Error != nil {
+		errMsg := fmt.Sprintf("pktvisor process error: %v", status.Error)
+		return backend.BackendError, errMsg, status.Error
+	}
+
+	if status.Complete {
+		err := p.proc.Stop()
+		return backend.Offline, "pktvisor process ended", err
+	}
+
+	if status.StopTs > 0 {
+		return backend.Offline, "pktvisor process ended", nil
+	}
+	return backend.Running, "", nil
+}
+
+// also used for HTTP REST API readiness check
+func (p *pktvisorBackend) getAppInfo() (AppInfo, error) {
+	var appInfo AppInfo
+	err := p.request("metrics/app", &appInfo, http.MethodGet, http.NoBody, "application/json", VersionTimeout)
+	return appInfo, err
+}

--- a/agent/backend/pktvisor/utils.go
+++ b/agent/backend/pktvisor/utils.go
@@ -24,7 +24,7 @@ func (p *pktvisorBackend) request(url string, payload interface{}, method string
 
 	status, _, err := p.getProcRunningStatus()
 	if status != backend.Running {
-		p.logger.Warn("ignoring pktvisor request because process is not running or is unresponsive", zap.String("url", url), zap.String("method", method), zap.Error(err))
+		p.logger.Warn("skipping pktvisor REST API request because process is not running or is unresponsive", zap.String("url", url), zap.String("method", method), zap.Error(err))
 		return err
 	}
 

--- a/agent/comms.go
+++ b/agent/comms.go
@@ -41,8 +41,10 @@ func (a *orbAgent) connect(ctx context.Context, config config.MQTTConfig) (mqtt.
 				case <-ctx.Done():
 					return
 				default:
-					if i, s, _ := a.backends["pktvisor"].GetState(); backend.Running != i {
-						a.logger.Info("waiting until pktvisor is in running state",
+					belist := backend.GetList()
+					firstBackend := belist[0]
+					if i, s, _ := a.backends[firstBackend].GetRunningStatus(); backend.Running != i {
+						a.logger.Info("waiting until a backend is in running state", zap.String("backend", firstBackend),
 							zap.String("current state", s), zap.String("wait time", (time.Duration(i)*time.Second).String()))
 						time.Sleep(time.Duration(i) * time.Second)
 						continue
@@ -54,7 +56,7 @@ func (a *orbAgent) connect(ctx context.Context, config config.MQTTConfig) (mqtt.
 				}
 			}
 			if !ok {
-				a.logger.Error("Pktvisor wasn't able to change to running, stopping connection")
+				a.logger.Error("backend wasn't able to change to running, stopping connection")
 				ctx.Done()
 			}
 		}()

--- a/agent/heartbeats.go
+++ b/agent/heartbeats.go
@@ -92,11 +92,13 @@ func (a *orbAgent) sendSingleHeartbeat(ctx context.Context, t time.Time, agentsS
 				pd.BackendErr = "backend is unreachable"
 			}
 			ps[pd.ID] = fleet.PolicyStateInfo{
-				Name:     pd.Name,
-				Version:  pd.Version,
-				State:    pstate,
-				Error:    pd.BackendErr,
-				Datasets: pd.GetDatasetIDs(),
+				Name:            pd.Name,
+				Version:         pd.Version,
+				State:           pstate,
+				Error:           pd.BackendErr,
+				Datasets:        pd.GetDatasetIDs(),
+				LastScrapeTS:    pd.LastScrapeTS,
+				LastScrapeBytes: pd.LastScrapeBytes,
 			}
 		}
 	} else {

--- a/agent/heartbeats.go
+++ b/agent/heartbeats.go
@@ -91,6 +91,7 @@ func (a *orbAgent) sendSingleHeartbeat(ctx context.Context, t time.Time, agentsS
 			}
 			ps[pd.ID] = fleet.PolicyStateInfo{
 				Name:     pd.Name,
+				Version:  pd.Version,
 				State:    pstate,
 				Error:    pd.BackendErr,
 				Datasets: pd.GetDatasetIDs(),

--- a/agent/heartbeats.go
+++ b/agent/heartbeats.go
@@ -55,6 +55,8 @@ func (a *orbAgent) sendSingleHeartbeat(ctx context.Context, t time.Time, agentsS
 				if err != nil {
 					a.logger.Error("failed to restart backend", zap.Error(err), zap.String("backend", name))
 				}
+			} else {
+				a.logger.Info("waiting to attempt backend restart due to failed status", zap.Duration("remaining", RestartTimeMin-(time.Now().Sub(be.GetStartTime()))))
 			}
 		} else {
 			// status is Running so no current error

--- a/agent/heartbeats.go
+++ b/agent/heartbeats.go
@@ -56,7 +56,7 @@ func (a *orbAgent) sendSingleHeartbeat(ctx context.Context, t time.Time, agentsS
 					a.logger.Error("failed to restart backend", zap.Error(err), zap.String("backend", name))
 				}
 			} else {
-				a.logger.Info("waiting to attempt backend restart due to failed status", zap.Duration("remaining", RestartTimeMin-(time.Now().Sub(be.GetStartTime()))))
+				a.logger.Info("waiting to attempt backend restart due to failed status", zap.Duration("remaining_secs", RestartTimeMin-(time.Now().Sub(be.GetStartTime()))))
 			}
 		} else {
 			// status is Running so no current error

--- a/agent/heartbeats.go
+++ b/agent/heartbeats.go
@@ -128,10 +128,6 @@ func (a *orbAgent) sendSingleHeartbeat(ctx context.Context, t time.Time, agentsS
 		return
 	}
 
-	// ##### DO NOT MERGE ####
-	a.logger.Debug("heartbeat dump", zap.Any("data", hbData))
-	// ##### DO NOT MERGE ####
-
 	if token := a.client.Publish(a.heartbeatsTopic, 1, false, body); token.Wait() && token.Error() != nil {
 		a.logger.Error("error sending heartbeat", zap.Error(token.Error()))
 		err = a.restartComms(ctx)

--- a/agent/policies/types.go
+++ b/agent/policies/types.go
@@ -7,18 +7,21 @@ package policies
 import (
 	"database/sql/driver"
 	_ "github.com/mattn/go-sqlite3"
+	"time"
 )
 
 type PolicyData struct {
-	ID         string
-	Datasets   map[string]bool
-	GroupIds   map[string]bool
-	Name       string
-	Backend    string
-	Version    int32
-	Data       interface{}
-	State      PolicyState
-	BackendErr string
+	ID              string
+	Datasets        map[string]bool
+	GroupIds        map[string]bool
+	Name            string
+	Backend         string
+	Version         int32
+	Data            interface{}
+	State           PolicyState
+	BackendErr      string
+	LastScrapeBytes int64
+	LastScrapeTS    time.Time
 }
 
 func (d *PolicyData) GetDatasetIDs() []string {
@@ -40,17 +43,6 @@ const (
 )
 
 type PolicyState int
-
-type policyData struct {
-	ID         string
-	Datasets   map[string]bool
-	Name       string
-	Backend    string
-	Version    int32
-	Data       interface{}
-	State      PolicyState
-	BackendErr string
-}
 
 var policyStateMap = [...]string{
 	"unknown",

--- a/agent/policies/types.go
+++ b/agent/policies/types.go
@@ -15,7 +15,7 @@ type PolicyData struct {
 	GroupIds   map[string]bool
 	Name       string
 	Backend    string
-	Version    int64
+	Version    int32
 	Data       interface{}
 	State      PolicyState
 	BackendErr string

--- a/agent/policies/types.go
+++ b/agent/policies/types.go
@@ -15,7 +15,7 @@ type PolicyData struct {
 	GroupIds   map[string]bool
 	Name       string
 	Backend    string
-	Version    int32
+	Version    int64
 	Data       interface{}
 	State      PolicyState
 	BackendErr string

--- a/agent/policyMgr/manager.go
+++ b/agent/policyMgr/manager.go
@@ -153,16 +153,13 @@ func (a *policyManager) RemovePolicy(policyID string, policyName string, beName 
 		return errors.New("policy remove for a backend we do not have, ignoring")
 	}
 	be := backend.GetBackend(beName)
-	// Remove policy via http request
 	err := be.RemovePolicy(pd)
 	if err != nil {
-		a.logger.Error("received error")
-		return err
+		a.logger.Error("backend remove policy failed: will still remove from PolicyManager", zap.String("policy_id", policyID), zap.Error(err))
 	}
 	// Remove policy from orb-agent local repo
 	err = a.repo.Remove(pd.ID)
 	if err != nil {
-
 		return err
 	}
 	return nil
@@ -220,10 +217,16 @@ func (a *policyManager) RemoveBackendPolicies(be backend.Backend, permanently bo
 			// note we continue here: even if the backend failed to remove, we update our policy repo to remove it
 		}
 		if permanently {
-			a.repo.Remove(plcy.ID)
+			err = a.repo.Remove(plcy.ID)
+			if err != nil {
+				return err
+			}
 		} else {
 			plcy.State = policies.Unknown
-			a.repo.Update(plcy)
+			err = a.repo.Update(plcy)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -247,7 +250,10 @@ func (a *policyManager) ApplyBackendPolicies(be backend.Backend) error {
 			policy.State = policies.Running
 			policy.BackendErr = ""
 		}
-		a.repo.Update(policy)
+		err = a.repo.Update(policy)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/agent/policyMgr/manager.go
+++ b/agent/policyMgr/manager.go
@@ -217,7 +217,7 @@ func (a *policyManager) RemoveBackendPolicies(be backend.Backend, permanently bo
 		err := be.RemovePolicy(plcy)
 		if err != nil {
 			a.logger.Error("failed to remove policy from backend", zap.String("policy_id", plcy.ID), zap.String("policy_name", plcy.Name), zap.Error(err))
-			return err
+			// note we continue here: even if the backend failed to remove, we update our policy repo to remove it
 		}
 		if permanently {
 			a.repo.Remove(plcy.ID)

--- a/fleet/comms_types.go
+++ b/fleet/comms_types.go
@@ -61,6 +61,7 @@ type PolicyStateInfo struct {
 	Datasets []string `json:"datasets,omitempty"`
 	State    string   `json:"state"`
 	Error    string   `json:"error,omitempty"`
+	Version  int64    `json:"version,omitempty"`
 }
 
 type GroupStateInfo struct {

--- a/fleet/comms_types.go
+++ b/fleet/comms_types.go
@@ -57,11 +57,13 @@ type BackendStateInfo struct {
 }
 
 type PolicyStateInfo struct {
-	Name     string   `json:"name"`
-	Datasets []string `json:"datasets,omitempty"`
-	State    string   `json:"state"`
-	Error    string   `json:"error,omitempty"`
-	Version  int32    `json:"version,omitempty"`
+	Name            string    `json:"name"`
+	Datasets        []string  `json:"datasets,omitempty"`
+	State           string    `json:"state"`
+	Error           string    `json:"error,omitempty"`
+	Version         int32     `json:"version,omitempty"`
+	LastScrapeBytes int64     `json:"last_scrape_bytes,omitempty"`
+	LastScrapeTS    time.Time `json:"last_scrape_ts,omitempty"`
 }
 
 type GroupStateInfo struct {

--- a/fleet/comms_types.go
+++ b/fleet/comms_types.go
@@ -61,7 +61,7 @@ type PolicyStateInfo struct {
 	Datasets []string `json:"datasets,omitempty"`
 	State    string   `json:"state"`
 	Error    string   `json:"error,omitempty"`
-	Version  int64    `json:"version,omitempty"`
+	Version  int32    `json:"version,omitempty"`
 }
 
 type GroupStateInfo struct {

--- a/fleet/comms_types.go
+++ b/fleet/comms_types.go
@@ -48,8 +48,11 @@ type Capabilities struct {
 const CurrentHeartbeatSchemaVersion = "1.0"
 
 type BackendStateInfo struct {
-	State string `json:"state"`
-	Error string `json:"error,omitempty"`
+	State             string    `json:"state"`
+	Error             string    `json:"error,omitempty"`
+	RestartCount      int64     `json:"restart_count,omitempty"`
+	LastRestartTS     time.Time `json:"last_restart_ts,omitempty"`
+	LastRestartReason string    `json:"last_restart_reason,omitempty"`
 }
 
 type PolicyStateInfo struct {

--- a/fleet/comms_types.go
+++ b/fleet/comms_types.go
@@ -51,6 +51,7 @@ type BackendStateInfo struct {
 	State             string    `json:"state"`
 	Error             string    `json:"error,omitempty"`
 	RestartCount      int64     `json:"restart_count,omitempty"`
+	LastError         string    `json:"last_error,omitempty"`
 	LastRestartTS     time.Time `json:"last_restart_ts,omitempty"`
 	LastRestartReason string    `json:"last_restart_reason,omitempty"`
 }


### PR DESCRIPTION
general improvements to orb-agent's handling of failures in the backend
 * split large pktvisor.go into smaller package files
 * add new "backend state" for tracking backend restarts
 * add more status on backend and policy state to heartbeats
 * don't error out when orb-agent fails to remove a policy from a backend; continue removing from the PolicyManager repo
 * when checking if pktvisor is alive, check both process status AND REST API accessibility
 * if backend is not running, update status for all policies on that backend to Unknown