### PR TITLE
[Feat] Compress otlp payload with brotli algorithm

### DIFF
--- a/agent/otel/otlpmqttexporter/otlp.go
+++ b/agent/otel/otlpmqttexporter/otlp.go
@@ -120,7 +120,6 @@ func (e *exporter) pushLogs(_ context.Context, _ plog.Logs) error {
 }
 
 func (e *exporter) export(_ context.Context, metricsTopic string, request []byte) error {
-	//compress payload 
 	compressedPayload := compressBrotli(request)
 	if token := e.config.Client.Publish(metricsTopic, 1, false, compressedPayload); token.Wait() && token.Error() != nil {
 		e.logger.Error("error sending metrics RPC", zap.String("topic", metricsTopic), zap.Error(token.Error()))

--- a/agent/otel/otlpmqttexporter/otlp.go
+++ b/agent/otel/otlpmqttexporter/otlp.go
@@ -126,7 +126,7 @@ func (e *exporter) export(_ context.Context, metricsTopic string, request []byte
 		e.logger.Error("error sending metrics RPC", zap.String("topic", metricsTopic), zap.Error(token.Error()))
 		return token.Error()
 	}
-	e.logger.Info("scraped and published metrics", zap.String("topic", metricsTopic), zap.Int("payload_size_b", len(compressedPayload)), zap.Int("regular_size_b", len(request)))
+	e.logger.Info("scraped and published metrics", zap.String("topic", metricsTopic), zap.Int("payload_size_b", len(request)), zap.Int("compressed_payload_size_b", len(compressedPayload)))
 
 	return nil
 }


### PR DESCRIPTION
Using OTLP the mqtt payload is bigger than regular way by some reason.
So this PR changes:
- compressed otlpmqtt payload with "BestCompression" using brotli algorithm, reducing it size in ~8x:

![image](https://user-images.githubusercontent.com/97463920/199382035-d9510c1d-2c07-4dfe-840b-3d1c9a390b27.png)

Metrics still arriving fine after some hours, no mqtt disconnects anymore:
![image](https://user-images.githubusercontent.com/97463920/199382150-0dcaeaca-4d1a-40f7-906b-fe83c5a5fe3d.png)

