### PR TITLE
[FIX] agent short form

### DIFF
--- a/agent/docker/orb-agent-entry.sh
+++ b/agent/docker/orb-agent-entry.sh
@@ -143,7 +143,7 @@ do
   # pid file dont exist
   if [ ! -f "/var/run/orb-agent.pid"  ]; then
     # running orb-agent in background
-    if [[ "$2" == '-c' ]]; then
+    if [[ "$2" == '-c' || "$3" == '-c' ]]; then
         # drop the pktvisor configuration file
         ORB_BACKENDS_PKTVISOR_CONFIG_FILE=""
     fi

--- a/agent/docker/orb-agent-entry.sh
+++ b/agent/docker/orb-agent-entry.sh
@@ -118,7 +118,10 @@ fi
 if [ "$PKTVISOR_PCAP_IFACE_DEFAULT" = 'mock' ]; then
   MAYBE_MOCK='pcap_source: mock'
 fi
-if [[ -n "${PKTVISOR_PCAP_IFACE_DEFAULT}" ]]; then
+if [[ -n "${PKTVISOR_PCAP_IFACE_DEFAULT}" || "${PKTVISOR_DNSTAP}" != 'true' && "${PKTVISOR_SFLOW}" != 'true' && "${PKTVISOR_NETFLOW}" != 'true' ]]; then
+  if [ "$PKTVISOR_PCAP_IFACE_DEFAULT" = '' ]; then
+    PKTVISOR_PCAP_IFACE_DEFAULT='auto'
+  fi
 (
 cat <<END
     default_pcap:

--- a/agent/docker/orb-agent-entry.sh
+++ b/agent/docker/orb-agent-entry.sh
@@ -143,6 +143,10 @@ do
   # pid file dont exist
   if [ ! -f "/var/run/orb-agent.pid"  ]; then
     # running orb-agent in background
+    if [[ "$2" == '-c' ]]; then
+        # drop the pktvisor configuration file
+        ORB_BACKENDS_PKTVISOR_CONFIG_FILE=""
+    fi
     nohup /run-agent.sh "$@" &
     sleep 2
     if [ -d "/nohup.out" ]; then


### PR DESCRIPTION
This PR fixes agent short form:

Command used to test:

`docker run -d --restart=always --net=host -v /home/user/Downloads/:/usr/local/orb/ -e ORB_CLOUD_MQTT_ID=6e72a741-f148-4c6d-ab47-18296ad3055d -e ORB_CLOUD_MQTT_CHANNEL_ID=6e72a741-f148-4c6d-ab47-18296ad3055d -e ORB_CLOUD_MQTT_KEY=6e72a741-f148-4c6d-ab47-18296ad3055d ns1labs/orb-agent:0.21.0-f8977f7c run -c /usr/local/orb/agent.yaml`

![image](https://user-images.githubusercontent.com/97463920/200885034-4af61331-fca3-4990-b00f-161bc0fff11b.png)