### PR TITLE
[FIX] agent message about default_pcap

### DIFF
--- a/agent/docker/orb-agent-entry.sh
+++ b/agent/docker/orb-agent-entry.sh
@@ -131,7 +131,7 @@ fi
 if [ "$PKTVISOR_PCAP_IFACE_DEFAULT" = 'mock' ]; then
   MAYBE_MOCK='pcap_source: mock'
 fi
-if [[ -n "${PKTVISOR_PCAP_IFACE_DEFAULT}" || "${PKTVISOR_PCAP}" == 'true' || "${PKTVISOR_DNSTAP}" != 'true' && "${PKTVISOR_SFLOW}" != 'true' && "${PKTVISOR_NETFLOW}" != 'true' ]]; then
+if [[ -n "${PKTVISOR_PCAP_IFACE_DEFAULT}" && $CONFIG_FILE_EXISTS == false || "${PKTVISOR_PCAP}" == 'true' || "${PKTVISOR_DNSTAP}" != 'true' && "${PKTVISOR_SFLOW}" != 'true' && "${PKTVISOR_NETFLOW}" != 'true' ]]; then
   echo "Setting default_pcap as visor tap"
   if [ "$PKTVISOR_PCAP_IFACE_DEFAULT" = '' ]; then
     PKTVISOR_PCAP_IFACE_DEFAULT='auto'


### PR DESCRIPTION
This PR remove the default_pcap tap when agent start with config file mounted