### PR TITLE
fix(sinks): quick fix sinks api

### DIFF
--- a/sinks/sinks_service.go
+++ b/sinks/sinks_service.go
@@ -89,6 +89,24 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 		return Sink{}, err
 	}
 
+	var currentSink Sink
+	if len(sink.Config) == 0 || len(sink.Tags) == 0 || sink.Description == "" {
+		currentSink, err = svc.sinkRepo.RetrieveById(ctx, sink.ID)
+		if err != nil {
+			return Sink{}, err
+		}
+	}
+
+	if len(sink.Config) == 0 {
+		sink.Config = currentSink.Config
+	}
+	if len(sink.Tags) == 0 {
+		sink.Tags = currentSink.Tags
+	}
+	if sink.Description == "" {
+		sink.Description = currentSink.Description
+	}
+
 	if sink.Backend != "" || sink.Error != "" {
 		return Sink{}, errors.ErrUpdateEntity
 	}

--- a/sinks/sinks_service_test.go
+++ b/sinks/sinks_service_test.go
@@ -116,6 +116,18 @@ func TestUpdateSink(t *testing.T) {
 	wrongSink := sinks.Sink{ID: wrongID.String()}
 	sink.ID = sk.ID
 
+	noConfig := sk
+	noConfig.Config = make(map[string]interface{})
+	noConfig.Name, _ = types.NewIdentifier("noConfig")
+
+	noTags := sk
+	noTags.Tags = make(map[string]string)
+	noTags.Name, _ = types.NewIdentifier("noTags")
+
+	noDescription := sk
+	noDescription.Tags = make(map[string]string)
+	noDescription.Name, _ = types.NewIdentifier("noDesc")
+
 	cases := map[string]struct {
 		sink  sinks.Sink
 		token string
@@ -141,11 +153,31 @@ func TestUpdateSink(t *testing.T) {
 			token: token,
 			err:   errors.ErrUpdateEntity,
 		},
+		"update existing sink without updating config": {
+			sink:  noConfig,
+			token: token,
+			err:   nil,
+		},
+		"update existing sink without updating tags": {
+			sink:  noTags,
+			token: token,
+			err:   nil,
+		},
+		"update existing sink without updating description": {
+			sink:  noDescription,
+			token: token,
+			err:   nil,
+		},
 	}
 
 	for desc, tc := range cases {
 		t.Run(desc, func(t *testing.T) {
-			_, err := service.UpdateSink(context.Background(), tc.token, tc.sink)
+			sink, err := service.UpdateSink(context.Background(), tc.token, tc.sink)
+			if err == nil {
+				assert.Equal(t, sk.Config, sink.Config, fmt.Sprintf("%s: expected %s got %s", desc, sk.Config, sink.Config))
+				assert.Equal(t, sk.Tags, sink.Tags, fmt.Sprintf("%s: expected %s got %s", desc, sk.Tags, sink.Tags))
+				assert.Equal(t, sk.Description, sink.Description, fmt.Sprintf("%s: expected %s got %s", desc, sk.Description, sink.Description))
+			}
 			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %d got %d", desc, tc.err, err))
 		})
 	}


### PR DESCRIPTION
Remove the need always to send all attributes when updating a sink
Current sink:
![image](https://user-images.githubusercontent.com/86990690/204279887-a6160bab-4d73-4ff9-9fbf-b4455e341d27.png)

Editing only sink name:
![image](https://user-images.githubusercontent.com/86990690/204280170-b6759640-9e15-4034-a3a3-4c1714e00f2b.png)

Editing only description:
![image](https://user-images.githubusercontent.com/86990690/204280500-c9b61a94-99f3-4f11-aa9d-8d4d6e318d6a.png)

Editing only tags:
![image](https://user-images.githubusercontent.com/86990690/204280654-f391fcba-d33b-4161-80e7-3092a16045a4.png)
