### PR TITLE
fleet(fix): remove omitempty of version field on PolicyStateInfo struct

### DIFF
--- a/fleet/comms_types.go
+++ b/fleet/comms_types.go
@@ -61,7 +61,7 @@ type PolicyStateInfo struct {
 	Datasets        []string  `json:"datasets,omitempty"`
 	State           string    `json:"state"`
 	Error           string    `json:"error,omitempty"`
-	Version         int32     `json:"version,omitempty"`
+	Version         int32     `json:"version"`
 	LastScrapeBytes int64     `json:"last_scrape_bytes,omitempty"`
 	LastScrapeTS    time.Time `json:"last_scrape_ts,omitempty"`
 	Backend         string    `json:"backend,omitempty"`


### PR DESCRIPTION
Remove omitempty on PolicyStateInfo struct so the version shows up even when it is 0

![version-policy](https://user-images.githubusercontent.com/86990690/206285545-9ca81bae-5df5-4465-9573-169f13130604.png)
