### PR TITLE
using agents.orb.live as mqtt address

### DIFF
--- a/python-test/features/integration_config_file.feature
+++ b/python-test/features/integration_config_file.feature
@@ -62,6 +62,71 @@ Scenario: provisioning agent without specify pktvisor path to config file (confi
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And remove the agent .yaml generated on each scenario
 
+@smoke @config_file @pktvisor_configs
+Scenario: provisioning agent without specify pktvisor binary path and path to config file (config file - auto_provision=false)
+    Given the Orb user has a registered account
+        And the Orb user logs in
+        And that a sink already exists
+        And a new agent is created with 2 orb tag(s)
+    When an agent(input_type:flow, settings: {"bind":"0.0.0.0", "port":"available_port"}) is provisioned via a configuration file on port available with 3 agent tags and has status online. [Overwrite default: True. Paste only file: True. Use specif backend for pktvisor {"binary":"None", "config_file":"None"}]
+        And pktvisor state is running
+        And edit the orb tags on agent and use 2 orb tag(s)
+        And 1 Agent Group(s) is created with all tags contained in the agent
+        And 3 simple policies same input_type as created via config file are applied to the group
+    Then 3 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
+        And this agent's heartbeat shows that 1 groups are matching the agent
+        And the container logs should contain the message "completed RPC subscription to group" within 30 seconds
+        And this agent's heartbeat shows that 3 policies are applied and all has status running
+        And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
+        And referred sink must have active state on response within 30 seconds
+        And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
+        And remove the agent .yaml generated on each scenario
+
+
+
+@smoke @config_file @pktvisor_configs
+Scenario: provisioning agent without specify pktvisor binary path (config file - auto_provision=false)
+    Given the Orb user has a registered account
+        And the Orb user logs in
+        And that a sink already exists
+        And a new agent is created with 2 orb tag(s)
+    When an agent(input_type:flow, settings: {"bind":"0.0.0.0", "port":"available_port"}) is provisioned via a configuration file on port available with 3 agent tags and has status online. [Overwrite default: True. Paste only file: True. Use specif backend for pktvisor {"config_file":"None"}]
+        And pktvisor state is running
+        And edit the orb tags on agent and use 2 orb tag(s)
+        And 1 Agent Group(s) is created with all tags contained in the agent
+        And 3 simple policies same input_type as created via config file are applied to the group
+    Then 3 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
+        And this agent's heartbeat shows that 1 groups are matching the agent
+        And the container logs should contain the message "completed RPC subscription to group" within 30 seconds
+        And this agent's heartbeat shows that 3 policies are applied and all has status running
+        And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
+        And referred sink must have active state on response within 30 seconds
+        And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
+        And remove the agent .yaml generated on each scenario
+
+
+
+@smoke @config_file @pktvisor_configs
+Scenario: provisioning agent without specify pktvisor path to config file (config file - auto_provision=false)
+    Given the Orb user has a registered account
+        And the Orb user logs in
+        And that a sink already exists
+        And a new agent is created with 2 orb tag(s)
+    When an agent(input_type:flow, settings: {"bind":"0.0.0.0", "port":"available_port"}) is provisioned via a configuration file on port available with 3 agent tags and has status online. [Overwrite default: True. Paste only file: True. Use specif backend for pktvisor {"binary":"None"}]
+        And pktvisor state is running
+        And edit the orb tags on agent and use 2 orb tag(s)
+        And 1 Agent Group(s) is created with all tags contained in the agent
+        And 3 simple policies same input_type as created via config file are applied to the group
+    Then 3 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
+        And this agent's heartbeat shows that 1 groups are matching the agent
+        And the container logs should contain the message "completed RPC subscription to group" within 30 seconds
+        And this agent's heartbeat shows that 3 policies are applied and all has status running
+        And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
+        And referred sink must have active state on response within 30 seconds
+        And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
+        And remove the agent .yaml generated on each scenario
+
+
 ########### tap_selector
 
 @smoke @config_file

--- a/python-test/features/steps/control_plane_agents.py
+++ b/python-test/features/steps/control_plane_agents.py
@@ -827,7 +827,7 @@ def create_agent_config_file(token, agent_name, iface, agent_tags, orb_url, base
     include_otel_env_var = configs.get('include_otel_env_var')
     enable_otel = configs.get('enable_otel')
     if configs.get('ignore_ssl_and_certificate_errors', 'false').lower() == 'true':
-        mqtt_url = f"{base_orb_address}:1883"
+        mqtt_url = f"agents.{base_orb_address}:1883"
         agent_config_file, tap = FleetAgent.config_file_of_orb_agent(agent_name, token, iface, orb_url, mqtt_url,
                                                                      tap_name,
                                                                      tls_verify=False, auto_provision=auto_provision,
@@ -840,7 +840,7 @@ def create_agent_config_file(token, agent_name, iface, agent_tags, orb_url, base
                                                                      enable_otel=enable_otel,
                                                                      overwrite_default=overwrite_default)
     else:
-        mqtt_url = "tls://" + base_orb_address + ":8883"
+        mqtt_url = "tls://agents." + base_orb_address + ":8883"
         agent_config_file, tap = FleetAgent.config_file_of_orb_agent(agent_name, token, iface, orb_url, mqtt_url,
                                                                      tap_name,
                                                                      auto_provision=auto_provision,


### PR DESCRIPTION
- Changing the mqtt address to use agents.orb.live
- Adding tests to validate default pktvisor configs in agents without auto provisioning