### PR TITLE
agents.orb.live as mqtt's default route

### DIFF
--- a/agent/docker/orb-agent-entry.sh
+++ b/agent/docker/orb-agent-entry.sh
@@ -30,7 +30,7 @@ orb_agent_bin="${ORB_AGENT_BIN:-/usr/local/bin/orb-agent}"
 # support generating API and MQTT addresses with one host name in ORB_CLOUD_ADDRESS
 if [[ -n "${ORB_CLOUD_ADDRESS}" ]]; then
   ORB_CLOUD_API_ADDRESS="https://${ORB_CLOUD_ADDRESS}"
-  ORB_CLOUD_MQTT_ADDRESS="tls://${ORB_CLOUD_ADDRESS}:8883"
+  ORB_CLOUD_MQTT_ADDRESS="tls://agents.${ORB_CLOUD_ADDRESS}:8883"
   export ORB_CLOUD_API_ADDRESS ORB_CLOUD_MQTT_ADDRESS
 fi
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -139,7 +139,7 @@ func mergeOrError(path string) {
 	v.SetDefault("orb.cloud.api.token", "")
 	v.SetDefault("orb.cloud.config.agent_name", "")
 	v.SetDefault("orb.cloud.config.auto_provision", true)
-	v.SetDefault("orb.cloud.mqtt.address", "tls://orb.live:8883")
+	v.SetDefault("orb.cloud.mqtt.address", "tls://agents.orb.live:8883")
 	v.SetDefault("orb.cloud.mqtt.id", "")
 	v.SetDefault("orb.cloud.mqtt.key", "")
 	v.SetDefault("orb.cloud.mqtt.channel_id", "")


### PR DESCRIPTION
This PR makes agents.orb.live the default mqtt route and the new mqtt routes in the form `tls://agents.${ORB_CLOUD_ADDRESS}:8883`
