### PR TITLE
fix: fix error status code from 500 to 409 for updating agent group or sink with a name conflict

### DIFF
--- a/fleet/postgres/agent_groups.go
+++ b/fleet/postgres/agent_groups.go
@@ -232,6 +232,8 @@ func (a agentGroupRepository) Update(ctx context.Context, ownerID string, group 
 			switch pqErr.Code.Name() {
 			case db.ErrInvalid, db.ErrTruncation:
 				return fleet.AgentGroup{}, errors.Wrap(fleet.ErrMalformedEntity, err)
+			case db.ErrDuplicate:
+				return fleet.AgentGroup{}, errors.Wrap(errors.ErrConflict, err)
 			}
 		}
 		return fleet.AgentGroup{}, errors.Wrap(fleet.ErrUpdateEntity, err)

--- a/fleet/postgres/agent_groups_test.go
+++ b/fleet/postgres/agent_groups_test.go
@@ -301,6 +301,18 @@ func TestAgentGroupUpdate(t *testing.T) {
 
 	group.ID = groupID
 
+	nameConflict, err := types.NewIdentifier("my-group-conflict")
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+	groupConflictName := fleet.AgentGroup{
+		Name:        nameConflict,
+		MFOwnerID:   oID.String(),
+		MFChannelID: chID.String(),
+		Tags:        types.Tags{"testkey": "testvalue"},
+	}
+
+	_, err = groupRepo.Save(context.Background(), groupConflictName)
+	require.Nil(t, err, fmt.Sprintf("unexpected error: %s\n", err))
+
 	cases := map[string]struct {
 		group fleet.AgentGroup
 		err   error
@@ -336,6 +348,16 @@ func TestAgentGroupUpdate(t *testing.T) {
 				MFOwnerID: "123",
 			},
 			err: errors.ErrMalformedEntity,
+		},
+		"update a existing group with name conflict": {
+			group: fleet.AgentGroup{
+				ID:          groupID,
+				Name:        nameConflict,
+				MFOwnerID:   oID.String(),
+				MFChannelID: chID.String(),
+				Tags:        types.Tags{"testkey": "testvalue"},
+			},
+			err: errors.ErrConflict,
 		},
 	}
 

--- a/sinks/postgres/sinks.go
+++ b/sinks/postgres/sinks.go
@@ -125,6 +125,8 @@ func (s sinksRepository) Update(ctx context.Context, sink sinks.Sink) error {
 			switch pqErr.Code.Name() {
 			case db.ErrInvalid, db.ErrTruncation:
 				return errors.Wrap(sinks.ErrMalformedEntity, err)
+			case db.ErrDuplicate:
+				return errors.Wrap(errors.ErrConflict, err)
 			}
 		}
 		return errors.Wrap(sinks.ErrUpdateEntity, err)


### PR DESCRIPTION
add a wrap for errors caused by name conflict on editing so that the status code will be 409 instead of 500