### PR TITLE
remove mandatory sink name on editing endpoint

### DIFF
--- a/sinks/api/http/endpoint.go
+++ b/sinks/api/http/endpoint.go
@@ -11,6 +11,7 @@ package http
 import (
 	"context"
 	"github.com/go-kit/kit/endpoint"
+	"github.com/ns1labs/orb/pkg/errors"
 	"github.com/ns1labs/orb/pkg/types"
 	"github.com/ns1labs/orb/sinks"
 	"github.com/ns1labs/orb/sinks/backend"
@@ -79,13 +80,19 @@ func updateSinkEndpoint(svc sinks.SinkService) endpoint.Endpoint {
 		if err := req.validate(); err != nil {
 			return nil, err
 		}
-		nameID, _ := types.NewIdentifier(req.Name)
 		sink := sinks.Sink{
-			Name:        nameID,
 			ID:          req.id,
 			Tags:        req.Tags,
 			Config:      req.Config,
 			Description: req.Description,
+		}
+
+		if req.Name != "" {
+			nameID, err := types.NewIdentifier(req.Name)
+			if err != nil {
+				return nil, errors.ErrMalformedEntity
+			}
+			sink.Name = nameID
 		}
 
 		sinkEdited, err := svc.UpdateSink(ctx, req.token, sink)

--- a/sinks/api/http/requests.go
+++ b/sinks/api/http/requests.go
@@ -63,13 +63,12 @@ func (req updateSinkReq) validate() error {
 		return errors.ErrUnauthorizedAccess
 	}
 
-	if req.Name == "" {
+	if req.id == "" {
 		return errors.ErrMalformedEntity
 	}
 
-	_, err := types.NewIdentifier(req.Name)
-	if err != nil {
-		return errors.Wrap(errors.ErrMalformedEntity, err)
+	if req.Description == "" && req.Name == "" && len(req.Tags) == 0 && len(req.Config) == 0 {
+		return errors.ErrMalformedEntity
 	}
 
 	return nil

--- a/sinks/sinks_service.go
+++ b/sinks/sinks_service.go
@@ -95,14 +95,11 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 		return Sink{}, err
 	}
 
-	if len(sink.Config) == 0 {
+	if sink.Config == nil {
 		sink.Config = currentSink.Config
 	}
 
 	if sink.Tags == nil {
-		sink.Tags = currentSink.Tags
-	} else if len(sink.Tags) != 0 {
-		currentSink.Tags.Merge(sink.Tags)
 		sink.Tags = currentSink.Tags
 	}
 
@@ -110,8 +107,7 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 		sink.Description = currentSink.Description
 	}
 
-	var newName string
-	if sink.Name.Scan(newName); newName == "" {
+	if newName := sink.Name.String(); newName == "" {
 		sink.Name = currentSink.Name
 	}
 

--- a/sinks/sinks_service.go
+++ b/sinks/sinks_service.go
@@ -110,6 +110,11 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 		sink.Description = currentSink.Description
 	}
 
+	var newName string
+	if sink.Name.Scan(newName); newName == "" {
+		sink.Name = currentSink.Name
+	}
+
 	if sink.Backend != "" || sink.Error != "" {
 		return Sink{}, errors.ErrUpdateEntity
 	}


### PR DESCRIPTION
following up https://github.com/ns1labs/orb/issues/1985#issuecomment-1355540797
remove the mandatory sink name on the payload for all editing requests unless you want to modify it

and roll back the last update on sink tags management to follow restful guidelines 