### PR TITLE
make config field mandatory on sinks creation

### DIFF
--- a/sinks/api/http/requests.go
+++ b/sinks/api/http/requests.go
@@ -46,10 +46,13 @@ func (req addReq) validate() error {
 		}
 		//currently, with only prometheus, 2 keys is enough, maybe change latter
 		if keySize >= 2 {
+			//minimal number of keys passed, valid config
 			return true
 		}
+		//still not get enough keys to create sink, check if there are more keys on map
 		return false
 	}) {
+		//not get enough keys to create sink, invalid config
 		return errors.ErrMalformedEntity
 	}
 

--- a/sinks/api/http/requests.go
+++ b/sinks/api/http/requests.go
@@ -37,6 +37,22 @@ func (req addReq) validate() error {
 		return errors.ErrUnauthorizedAccess
 	}
 
+	keySize := 0
+	if req.Config == nil {
+		return errors.ErrMalformedEntity
+	} else if !req.Config.IsApplicable(func(key string, value interface{}) bool {
+		if key != "" {
+			keySize++
+		}
+		//currently, with only prometheus, 2 keys is enough, maybe change latter
+		if keySize >= 2 {
+			return true
+		}
+		return false
+	}) {
+		return errors.ErrMalformedEntity
+	}
+
 	if req.Name == "" {
 		return errors.ErrMalformedEntity
 	}


### PR DESCRIPTION
Make sink config mandatory on sink creation and check if it has the minimum amount of keys to create

*Plus make some unit tests more readable