### PR TITLE
add an error message when policy format is different from creation

### DIFF
--- a/policies/api/http/endpoint_test.go
+++ b/policies/api/http/endpoint_test.go
@@ -435,6 +435,21 @@ func TestPolicyEdition(t *testing.T) {
 			status:      http.StatusBadRequest,
 			data:        invalidNamePolicyJson,
 		},
+		"update policy data in json format that was created in yaml ": {
+			id:          policy.ID,
+			contentType: "application/json",
+			auth:        token,
+			status:      http.StatusBadRequest,
+			data: toJSON(updatePolicyReq{
+				Name:   "test",
+				Format: "json",
+				Policy: types.Metadata{
+					"kind":     "collection",
+					"input":    map[string]string{"input_type": "pcap"},
+					"handlers": map[string]string{"type": "net"},
+				},
+			}),
+		},
 	}
 
 	for desc, tc := range cases {
@@ -1467,4 +1482,15 @@ type duplicatePolicyReq struct {
 	id    string
 	token string
 	Name  string `json:"name,omitempty"`
+}
+
+type updatePolicyReq struct {
+	id          string
+	token       string
+	Name        string         `json:"name,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Tags        types.Tags     `json:"tags,omitempty"`
+	Policy      types.Metadata `json:"policy,omitempty"`
+	PolicyData  string         `json:"policy_data,omitempty"`
+	Format      string         `json:"format,omitempty"`
 }

--- a/policies/policy_service.go
+++ b/policies/policy_service.go
@@ -141,6 +141,11 @@ func (s policiesService) EditPolicy(ctx context.Context, token string, pol Polic
 	pol.MFOwnerID = ownerID
 	pol.Version = currentPol.Version
 
+	if pol.Format != "" && pol.Format != currentPol.Format {
+		return Policy{}, errors.Wrap(errors.New("Can't change policy format after creation"), errors.ErrMalformedEntity)
+	}
+	pol.Format = currentPol.Format
+
 	// If backend policy is not being edited, retrieve saved one
 	if pol.PolicyData == "" && pol.Policy == nil {
 		pol.Policy = currentPol.Policy


### PR DESCRIPTION
Once the policy is created in JSON format or YAML, it can't edit in a different format or change its format