### PR TITLE
Fix/remove mandatory name editing

### DIFF
--- a/fleet/agent_group_service.go
+++ b/fleet/agent_group_service.go
@@ -116,6 +116,15 @@ func (svc fleetService) EditAgentGroup(ctx context.Context, token string, group 
 		return AgentGroup{}, err
 	}
 
+	currentAgentGroup, err := svc.agentGroupRepository.RetrieveByID(ctx, group.ID, ownerID)
+	if err != nil {
+		return AgentGroup{}, err
+	}
+
+	if newName := group.Name.String(); newName == "" {
+		group.Name = currentAgentGroup.Name
+	}
+
 	ag, err := svc.agentGroupRepository.Update(ctx, ownerID, group)
 	if err != nil {
 		return AgentGroup{}, err

--- a/fleet/agent_service.go
+++ b/fleet/agent_service.go
@@ -186,6 +186,15 @@ func (svc fleetService) EditAgent(ctx context.Context, token string, agent Agent
 	}
 	agent.MFOwnerID = ownerID
 
+	currentAgent, err := svc.agentRepo.RetrieveByID(ctx, ownerID, agent.MFThingID)
+	if err != nil {
+		return Agent{}, err
+	}
+
+	if newName := agent.Name.String(); newName == "" {
+		agent.Name = currentAgent.Name
+	}
+
 	err = svc.agentRepo.UpdateAgentByID(ctx, ownerID, agent)
 	if err != nil {
 		return Agent{}, err

--- a/fleet/api/http/endpoint.go
+++ b/fleet/api/http/endpoint.go
@@ -355,9 +355,12 @@ func editAgentEndpoint(svc fleet.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		validName, err := types.NewIdentifier(req.Name)
-		if err != nil {
-			return nil, err
+		var validName types.Identifier
+		if req.Name != "" {
+			validName, err = types.NewIdentifier(req.Name)
+			if err != nil {
+				return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+			}
 		}
 		agent := fleet.Agent{
 			Name:      validName,

--- a/fleet/api/http/endpoint.go
+++ b/fleet/api/http/endpoint.go
@@ -117,9 +117,12 @@ func editAgentGroupEndpoint(svc fleet.Service) endpoint.Endpoint {
 			return agentGroupRes{}, err
 		}
 
-		validName, err := types.NewIdentifier(req.Name)
-		if err != nil {
-			return agentGroupRes{}, err
+		var validName types.Identifier
+		if req.Name != "" {
+			validName, err = types.NewIdentifier(req.Name)
+			if err != nil {
+				return agentGroupRes{}, errors.Wrap(errors.ErrMalformedEntity, err)
+			}
 		}
 		ag := fleet.AgentGroup{
 			ID:          req.id,

--- a/fleet/api/http/endpoint_test.go
+++ b/fleet/api/http/endpoint_test.go
@@ -469,24 +469,6 @@ func TestUpdateAgentGroup(t *testing.T) {
 	ag, err := createAgentGroup(t, "ue-agent-group", &cli)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
-	data := toJSON(updateAgentGroupReq{
-		Name:        ag.Name.String(),
-		Description: ag.Description,
-		Tags:        ag.Tags,
-	})
-
-	invalidName := toJSON(updateAgentGroupReq{
-		Name:        "g",
-		Description: ag.Description,
-		Tags:        ag.Tags,
-	})
-
-	missingTagsdata := toJSON(updateAgentGroupReq{
-		Name:        ag.Name.String(),
-		Description: ag.Description,
-		Tags:        map[string]string{},
-	})
-
 	cases := map[string]struct {
 		req         string
 		id          string
@@ -495,7 +477,11 @@ func TestUpdateAgentGroup(t *testing.T) {
 		status      int
 	}{
 		"update existing agent group": {
-			req:         data,
+			req: toJSON(updateAgentGroupReq{
+				Name:        ag.Name.String(),
+				Description: ag.Description,
+				Tags:        ag.Tags,
+			}),
 			id:          ag.ID,
 			contentType: contentType,
 			auth:        token,
@@ -509,42 +495,66 @@ func TestUpdateAgentGroup(t *testing.T) {
 			status:      http.StatusBadRequest,
 		},
 		"update agent group with a invalid id": {
-			req:         data,
+			req: toJSON(updateAgentGroupReq{
+				Name:        ag.Name.String(),
+				Description: ag.Description,
+				Tags:        ag.Tags,
+			}),
 			id:          "invalid",
 			contentType: contentType,
 			auth:        token,
 			status:      http.StatusNotFound,
 		},
 		"update non-existing agent group": {
-			req:         data,
+			req: toJSON(updateAgentGroupReq{
+				Name:        ag.Name.String(),
+				Description: ag.Description,
+				Tags:        ag.Tags,
+			}),
 			id:          wrongID,
 			contentType: contentType,
 			auth:        token,
 			status:      http.StatusNotFound,
 		},
 		"update agent group with invalid user token": {
-			req:         data,
+			req: toJSON(updateAgentGroupReq{
+				Name:        ag.Name.String(),
+				Description: ag.Description,
+				Tags:        ag.Tags,
+			}),
 			id:          ag.ID,
 			contentType: contentType,
 			auth:        "invalid",
 			status:      http.StatusUnauthorized,
 		},
 		"update agent group with empty user token": {
-			req:         data,
+			req: toJSON(updateAgentGroupReq{
+				Name:        ag.Name.String(),
+				Description: ag.Description,
+				Tags:        ag.Tags,
+			}),
 			id:          ag.ID,
 			contentType: contentType,
 			auth:        "",
 			status:      http.StatusUnauthorized,
 		},
 		"update agent group with invalid content type": {
-			req:         data,
+			req: toJSON(updateAgentGroupReq{
+				Name:        ag.Name.String(),
+				Description: ag.Description,
+				Tags:        ag.Tags,
+			}),
 			id:          ag.ID,
 			contentType: "invalid",
 			auth:        token,
 			status:      http.StatusUnsupportedMediaType,
 		},
 		"update agent group without content type": {
-			req:         data,
+			req: toJSON(updateAgentGroupReq{
+				Name:        ag.Name.String(),
+				Description: ag.Description,
+				Tags:        ag.Tags,
+			}),
 			id:          ag.ID,
 			contentType: "",
 			auth:        token,
@@ -572,18 +582,36 @@ func TestUpdateAgentGroup(t *testing.T) {
 			status:      http.StatusBadRequest,
 		},
 		"add a agent group with invalid name": {
-			req:         invalidName,
+			req: toJSON(updateAgentGroupReq{
+				Name:        "g",
+				Description: ag.Description,
+				Tags:        ag.Tags,
+			}),
 			id:          ag.ID,
 			contentType: contentType,
 			auth:        token,
 			status:      http.StatusBadRequest,
 		},
 		"update existing agent group without tags": {
-			req:         missingTagsdata,
+			req: toJSON(updateAgentGroupReq{
+				Name:        ag.Name.String(),
+				Description: ag.Description,
+				Tags:        map[string]string{},
+			}),
 			id:          ag.ID,
 			contentType: contentType,
 			auth:        token,
 			status:      http.StatusBadRequest,
+		},
+		"update existing agent group without name": {
+			req: toJSON(updateAgentGroupReq{
+				Description: ag.Description,
+				Tags:        ag.Tags,
+			}),
+			id:          ag.ID,
+			contentType: contentType,
+			auth:        token,
+			status:      http.StatusOK,
 		},
 	}
 

--- a/fleet/api/http/endpoint_test.go
+++ b/fleet/api/http/endpoint_test.go
@@ -1070,16 +1070,6 @@ func TestUpdateAgent(t *testing.T) {
 	ag, err := createAgent(t, "my-agent1", &cli)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
-	data := toJSON(updateAgentReq{
-		Name: ag.Name.String(),
-		Tags: ag.OrbTags,
-	})
-
-	invalidNameData := toJSON(updateAgentReq{
-		Name: "a",
-		Tags: ag.OrbTags,
-	})
-
 	cases := map[string]struct {
 		req         string
 		id          string
@@ -1088,7 +1078,10 @@ func TestUpdateAgent(t *testing.T) {
 		status      int
 	}{
 		"update existing agent": {
-			req:         data,
+			req: toJSON(updateAgentReq{
+				Name: ag.Name.String(),
+				Tags: ag.OrbTags,
+			}),
 			id:          ag.MFThingID,
 			contentType: contentType,
 			auth:        token,
@@ -1102,42 +1095,60 @@ func TestUpdateAgent(t *testing.T) {
 			status:      http.StatusBadRequest,
 		},
 		"update agent with a invalid id": {
-			req:         data,
+			req: toJSON(updateAgentReq{
+				Name: ag.Name.String(),
+				Tags: ag.OrbTags,
+			}),
 			id:          "invalid",
 			contentType: contentType,
 			auth:        token,
 			status:      http.StatusNotFound,
 		},
 		"update non-existing agent": {
-			req:         data,
+			req: toJSON(updateAgentReq{
+				Name: ag.Name.String(),
+				Tags: ag.OrbTags,
+			}),
 			id:          wrongID,
 			contentType: contentType,
 			auth:        token,
 			status:      http.StatusNotFound,
 		},
 		"update agent with invalid user token": {
-			req:         data,
+			req: toJSON(updateAgentReq{
+				Name: ag.Name.String(),
+				Tags: ag.OrbTags,
+			}),
 			id:          ag.MFThingID,
 			contentType: contentType,
 			auth:        "invalid",
 			status:      http.StatusUnauthorized,
 		},
 		"update agent with empty user token": {
-			req:         data,
+			req: toJSON(updateAgentReq{
+				Name: ag.Name.String(),
+				Tags: ag.OrbTags,
+			}),
 			id:          ag.MFThingID,
 			contentType: contentType,
 			auth:        "",
 			status:      http.StatusUnauthorized,
 		},
 		"update agent with invalid content type": {
-			req:         data,
+			req: toJSON(updateAgentReq{
+				Name: ag.Name.String(),
+				Tags: ag.OrbTags,
+			}),
 			id:          ag.MFThingID,
 			contentType: "invalid",
 			auth:        token,
 			status:      http.StatusUnsupportedMediaType,
 		},
 		"update agent without content type": {
-			req:         data,
+			req: toJSON(updateAgentReq{
+				Name: ag.Name.String(),
+				Tags: ag.OrbTags,
+			}),
 			id:          ag.MFThingID,
 			contentType: "",
 			auth:        token,
@@ -1165,11 +1176,23 @@ func TestUpdateAgent(t *testing.T) {
 			status:      http.StatusBadRequest,
 		},
 		"update existing agent with invalid name": {
-			req:         invalidNameData,
+			req: toJSON(updateAgentReq{
+				Name: "a",
+				Tags: ag.OrbTags,
+			}),
 			id:          ag.MFThingID,
 			contentType: contentType,
 			auth:        token,
 			status:      http.StatusBadRequest,
+		},
+		"update existing agent without name": {
+			req: toJSON(updateAgentReq{
+				Tags: ag.OrbTags,
+			}),
+			id:          ag.MFThingID,
+			contentType: contentType,
+			auth:        token,
+			status:      http.StatusOK,
 		},
 	}
 

--- a/fleet/api/http/requests.go
+++ b/fleet/api/http/requests.go
@@ -106,13 +106,9 @@ func (req updateAgentReq) validate() error {
 	if req.token == "" {
 		return errors.ErrUnauthorizedAccess
 	}
-	if req.Name == "" {
-		return errors.ErrMalformedEntity
-	}
 
-	_, err := types.NewIdentifier(req.Name)
-	if err != nil {
-		return errors.Wrap(errors.ErrMalformedEntity, err)
+	if req.Name == "" && req.Tags == nil {
+		return errors.ErrMalformedEntity
 	}
 
 	return nil

--- a/fleet/api/http/requests.go
+++ b/fleet/api/http/requests.go
@@ -63,16 +63,8 @@ func (req updateAgentGroupReq) validate() error {
 	if req.token == "" {
 		return errors.ErrUnauthorizedAccess
 	}
-	if req.Name == "" {
-		return errors.ErrMalformedEntity
-	}
 	if len(req.Tags) == 0 {
 		return errors.ErrMalformedEntity
-	}
-
-	_, err := types.NewIdentifier(req.Name)
-	if err != nil {
-		return errors.Wrap(errors.ErrMalformedEntity, err)
 	}
 
 	return nil

--- a/fleet/mocks/agent.go
+++ b/fleet/mocks/agent.go
@@ -67,7 +67,12 @@ func (a agentRepositoryMock) UpdateAgentByID(_ context.Context, ownerID string, 
 		if a.agentsMock[agent.MFThingID].MFOwnerID != ownerID {
 			return fleet.ErrUpdateEntity
 		}
-		a.agentsMock[agent.MFThingID] = agent
+
+		currentGroup := a.agentsMock[agent.MFThingID]
+		currentGroup.Name = agent.Name
+		currentGroup.OrbTags = agent.OrbTags
+
+		a.agentsMock[agent.MFThingID] = currentGroup
 		return nil
 	}
 	return fleet.ErrNotFound

--- a/fleet/mocks/agent_groups.go
+++ b/fleet/mocks/agent_groups.go
@@ -96,7 +96,13 @@ func (a *agentGroupRepositoryMock) Update(ctx context.Context, ownerID string, g
 		if a.agentGroupMock[group.ID].MFOwnerID != ownerID {
 			return fleet.AgentGroup{}, fleet.ErrUpdateEntity
 		}
-		a.agentGroupMock[group.ID] = group
+		currentGroup := a.agentGroupMock[group.ID]
+		currentGroup.Name = group.Name
+		currentGroup.Description = group.Description
+		currentGroup.Tags = group.Tags
+
+		a.agentGroupMock[group.ID] = currentGroup
+
 		return a.agentGroupMock[group.ID], nil
 	}
 	return fleet.AgentGroup{}, fleet.ErrNotFound

--- a/policies/api/http/endpoint.go
+++ b/policies/api/http/endpoint.go
@@ -242,13 +242,16 @@ func editDatasetEndpoint(svc policies.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		nID, err := types.NewIdentifier(req.Name)
-		if err != nil {
-			return nil, err
+		var nameID types.Identifier
+		if req.Name != "" {
+			nameID, err = types.NewIdentifier(req.Name)
+			if err != nil {
+				return policyUpdateRes{}, errors.Wrap(errors.ErrMalformedEntity, err)
+			}
 		}
 
 		dataset := policies.Dataset{
-			Name:    nID,
+			Name:    nameID,
 			ID:      req.id,
 			Tags:    req.Tags,
 			SinkIDs: req.SinkIDs,

--- a/policies/api/http/endpoint_test.go
+++ b/policies/api/http/endpoint_test.go
@@ -813,45 +813,73 @@ func TestDatasetEdition(t *testing.T) {
 			contentType: "application/json",
 			auth:        token,
 			status:      http.StatusOK,
-			data:        validDatasetJson,
+			data: toJSON(updateDatasetReq{
+				Name:    "dataset",
+				Tags:    map[string]string{"region": "eu", "node_type": "dns"},
+				SinkIDs: []string{"03679425-aa69-4574-bf62-e0fe71b80939", "03679425-aa69-4574-bf62-e0fe71b80939"},
+			}),
 		},
 		"update dataset with a invalid id": {
-			data:        validDatasetJson,
+			data: toJSON(updateDatasetReq{
+				Name:    "dataset",
+				Tags:    map[string]string{"region": "eu", "node_type": "dns"},
+				SinkIDs: []string{"03679425-aa69-4574-bf62-e0fe71b80939", "03679425-aa69-4574-bf62-e0fe71b80939"},
+			}),
 			id:          "invalid",
 			contentType: contentType,
 			auth:        token,
 			status:      http.StatusNotFound,
 		},
 		"update non-existing dataset": {
-			data:        validDatasetJson,
+			data: toJSON(updateDatasetReq{
+				Name:    "dataset",
+				Tags:    map[string]string{"region": "eu", "node_type": "dns"},
+				SinkIDs: []string{"03679425-aa69-4574-bf62-e0fe71b80939", "03679425-aa69-4574-bf62-e0fe71b80939"},
+			}),
 			id:          wrongID,
 			contentType: contentType,
 			auth:        token,
 			status:      http.StatusNotFound,
 		},
 		"update dataset with invalid user token": {
-			data:        validDatasetJson,
+			data: toJSON(updateDatasetReq{
+				Name:    "dataset",
+				Tags:    map[string]string{"region": "eu", "node_type": "dns"},
+				SinkIDs: []string{"03679425-aa69-4574-bf62-e0fe71b80939", "03679425-aa69-4574-bf62-e0fe71b80939"},
+			}),
 			id:          dataset.ID,
 			contentType: contentType,
 			auth:        "invalid",
 			status:      http.StatusUnauthorized,
 		},
 		"update dataset with empty user token": {
-			data:        validDatasetJson,
+			data: toJSON(updateDatasetReq{
+				Name:    "dataset",
+				Tags:    map[string]string{"region": "eu", "node_type": "dns"},
+				SinkIDs: []string{"03679425-aa69-4574-bf62-e0fe71b80939", "03679425-aa69-4574-bf62-e0fe71b80939"},
+			}),
 			id:          dataset.ID,
 			contentType: contentType,
 			auth:        "",
 			status:      http.StatusUnauthorized,
 		},
 		"update dataset with invalid content type": {
-			data:        validDatasetJson,
+			data: toJSON(updateDatasetReq{
+				Name:    "dataset",
+				Tags:    map[string]string{"region": "eu", "node_type": "dns"},
+				SinkIDs: []string{"03679425-aa69-4574-bf62-e0fe71b80939", "03679425-aa69-4574-bf62-e0fe71b80939"},
+			}),
 			id:          dataset.ID,
 			contentType: "invalid",
 			auth:        token,
 			status:      http.StatusUnsupportedMediaType,
 		},
 		"update dataset without content type": {
-			data:        validDatasetJson,
+			data: toJSON(updateDatasetReq{
+				Name:    "dataset",
+				Tags:    map[string]string{"region": "eu", "node_type": "dns"},
+				SinkIDs: []string{"03679425-aa69-4574-bf62-e0fe71b80939", "03679425-aa69-4574-bf62-e0fe71b80939"},
+			}),
 			id:          dataset.ID,
 			contentType: "",
 			auth:        token,
@@ -876,7 +904,21 @@ func TestDatasetEdition(t *testing.T) {
 			contentType: "application/json",
 			auth:        token,
 			status:      http.StatusBadRequest,
-			data:        validDatasetJson,
+			data: toJSON(updateDatasetReq{
+				Name:    "dataset",
+				Tags:    map[string]string{"region": "eu", "node_type": "dns"},
+				SinkIDs: []string{"03679425-aa69-4574-bf62-e0fe71b80939", "03679425-aa69-4574-bf62-e0fe71b80939"},
+			}),
+		},
+		"update a existing dataset without name": {
+			id:          dataset.ID,
+			contentType: "application/json",
+			auth:        token,
+			status:      http.StatusOK,
+			data: toJSON(updateDatasetReq{
+				Tags:    map[string]string{"region": "eu", "node_type": "dns"},
+				SinkIDs: []string{"03679425-aa69-4574-bf62-e0fe71b80939", "03679425-aa69-4574-bf62-e0fe71b80939"},
+			}),
 		},
 	}
 
@@ -1467,4 +1509,12 @@ type duplicatePolicyReq struct {
 	id    string
 	token string
 	Name  string `json:"name,omitempty"`
+}
+
+type updateDatasetReq struct {
+	Name    string `json:"name,omitempty"`
+	id      string
+	token   string
+	Tags    types.Tags `json:"tags,omitempty"`
+	SinkIDs []string   `json:"sink_ids,omitempty"`
 }

--- a/policies/policy_service.go
+++ b/policies/policy_service.go
@@ -291,6 +291,14 @@ func (s policiesService) EditDataset(ctx context.Context, token string, ds Datas
 		return Dataset{}, err
 	}
 
+	if ds.Name.String() == "" {
+		currentDataset, err := s.repo.RetrieveDatasetByID(ctx, ds.ID, ds.MFOwnerID)
+		if err != nil {
+			return Dataset{}, err
+		}
+		ds.Name = currentDataset.Name
+	}
+
 	err = s.repo.UpdateDataset(ctx, mfOwnerID, ds)
 	if err != nil {
 		return Dataset{}, err

--- a/policies/policy_service_test.go
+++ b/policies/policy_service_test.go
@@ -490,12 +490,12 @@ func TestEditDataset(t *testing.T) {
 		"update a existing dataset": {
 			ds: policies.Dataset{
 				ID:        dataset.ID,
-				Name:      nameID,
+				Name:      validName,
 				MFOwnerID: dataset.MFOwnerID,
 				SinkIDs:   dataset.SinkIDs,
 			},
 			expectedDS: policies.Dataset{
-				Name:    nameID,
+				Name:    validName,
 				SinkIDs: dataset.SinkIDs,
 			},
 			token: token,
@@ -523,7 +523,7 @@ func TestEditDataset(t *testing.T) {
 				SinkIDs:   dataset.SinkIDs,
 			},
 			expectedDS: policies.Dataset{
-				Name:    nameID,
+				Name:    validName,
 				SinkIDs: dataset.SinkIDs,
 			},
 			token: token,


### PR DESCRIPTION
allow partial updates by removing mandatory name for editing requests for agents, agent groups, and datasets. following these rules:

- If the name is informed, the new name must overwrite the old name
- If the name is omitted, the old name must be maintained.
- If the name is informed with empty, the old name must be maintained.
- If the name is informed with an invalid value, an error must be raised informing that the name doesn't match the pattern required.