### PR TITLE
[ORB-223] Fix/partial updates policies

### DIFF
--- a/fleet/agent_group_service.go
+++ b/fleet/agent_group_service.go
@@ -125,14 +125,12 @@ func (svc fleetService) EditAgentGroup(ctx context.Context, token string, group 
 		group.Name = currentAgentGroup.Name
 	}
 
-	if group.Description == "" {
+	if group.Description == nil {
 		group.Description = currentAgentGroup.Description
 	}
 
 	if group.Tags == nil {
 		group.Tags = currentAgentGroup.Tags
-	} else if len(group.Tags) == 0 {
-		return AgentGroup{}, errors.ErrMalformedEntity
 	}
 
 	ag, err := svc.agentGroupRepository.Update(ctx, ownerID, group)

--- a/fleet/agent_group_service_test.go
+++ b/fleet/agent_group_service_test.go
@@ -44,11 +44,12 @@ const (
 )
 
 var (
-	agentGroup = fleet.AgentGroup{
+	description = "An example agent group representing european dns nodes"
+	agentGroup  = fleet.AgentGroup{
 		ID:          "",
 		MFOwnerID:   "",
 		Name:        types.Identifier{},
-		Description: "",
+		Description: &description,
 		MFChannelID: "",
 		Tags:        nil,
 		Created:     time.Time{},
@@ -123,7 +124,7 @@ func TestCreateAgentGroup(t *testing.T) {
 	validAgent := fleet.AgentGroup{
 		MFOwnerID:   ownerID.String(),
 		Name:        nameID,
-		Description: "An example agent group representing european dns nodes",
+		Description: &description,
 		Tags:        make(map[string]string),
 		Created:     time.Time{},
 	}
@@ -326,6 +327,10 @@ func TestUpdateAgentGroup(t *testing.T) {
 	}
 	_, err = fleetService.CreateAgent(context.Background(), token, agent)
 
+	emptyDescription := ""
+
+	groupTestDescriptionAttribute, err := createAgentGroup(t, "test-description", fleetService)
+
 	cases := map[string]struct {
 		group         fleet.AgentGroup
 		expectedGroup fleet.AgentGroup
@@ -356,7 +361,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 			token: token,
 			err:   errors.ErrUpdateEntity,
 		},
-		"update existing agent without name": {
+		"update existing agent with omitted name": {
 			group: fleet.AgentGroup{
 				ID:        ag.ID,
 				MFOwnerID: ag.MFOwnerID,
@@ -383,17 +388,17 @@ func TestUpdateAgentGroup(t *testing.T) {
 			token: token,
 			err:   nil,
 		},
-		"update existing agent group with description empty": {
+		"update existing agent group with empty description": {
 			group: fleet.AgentGroup{
-				ID:          ag.ID,
-				Name:        ag.Name,
-				MFOwnerID:   ag.MFOwnerID,
-				Description: "",
+				ID:          groupTestDescriptionAttribute.ID,
+				Name:        groupTestDescriptionAttribute.Name,
+				MFOwnerID:   groupTestDescriptionAttribute.MFOwnerID,
+				Description: &emptyDescription,
 			},
 			expectedGroup: fleet.AgentGroup{
-				Name:        ag.Name,
-				Tags:        ag.Tags,
-				Description: ag.Description,
+				Name:        groupTestDescriptionAttribute.Name,
+				Tags:        groupTestDescriptionAttribute.Tags,
+				Description: &emptyDescription,
 			},
 			token: token,
 			err:   nil,
@@ -407,11 +412,11 @@ func TestUpdateAgentGroup(t *testing.T) {
 			},
 			expectedGroup: fleet.AgentGroup{
 				Name:        ag.Name,
-				Tags:        ag.Tags,
+				Tags:        map[string]string{},
 				Description: ag.Description,
 			},
 			token: token,
-			err:   errors.ErrMalformedEntity,
+			err:   nil,
 		},
 		"update existing agent group with tags omitted": {
 			group: fleet.AgentGroup{
@@ -433,7 +438,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 			agentGroupTest, err := fleetService.EditAgentGroup(context.Background(), tc.token, tc.group)
 			if err == nil {
-				assert.Equal(t, tc.expectedGroup.Description, agentGroupTest.Description, fmt.Sprintf("%s: expected %s got %s", desc, tc.expectedGroup.Description, agentGroupTest.Description))
+				assert.Equal(t, *tc.expectedGroup.Description, *agentGroupTest.Description, fmt.Sprintf("%s: expected %s got %s", desc, *tc.expectedGroup.Description, *agentGroupTest.Description))
 				assert.Equal(t, tc.expectedGroup.Name, agentGroupTest.Name, fmt.Sprintf("%s: expected %s got %s", desc, tc.expectedGroup.Name, agentGroupTest.Name))
 			}
 			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %d got %d", desc, tc.err, err))
@@ -495,7 +500,7 @@ func createAgentGroup(t *testing.T, name string, svc fleet.AgentGroupService) (f
 		return fleet.AgentGroup{}, err
 	}
 	agCopy.Name = validName
-	agCopy.Description = "example"
+	agCopy.Description = &description
 	agCopy.Tags = map[string]string{
 		"tag": "test",
 	}
@@ -539,7 +544,7 @@ func TestValidateAgentGroup(t *testing.T) {
 	validAgent := fleet.AgentGroup{
 		MFOwnerID:   ownerID.String(),
 		Name:        nameID,
-		Description: "An example agent group representing european dns nodes",
+		Description: &description,
 		Tags:        make(map[string]string),
 	}
 

--- a/fleet/agent_groups.go
+++ b/fleet/agent_groups.go
@@ -15,7 +15,7 @@ type AgentGroup struct {
 	ID             string
 	MFOwnerID      string
 	Name           types.Identifier
-	Description    string
+	Description    *string
 	MFChannelID    string
 	Tags           types.Tags
 	Created        time.Time

--- a/fleet/api/http/endpoint.go
+++ b/fleet/api/http/endpoint.go
@@ -30,7 +30,7 @@ func addAgentGroupEndpoint(svc fleet.Service) endpoint.Endpoint {
 
 		group := fleet.AgentGroup{
 			Name:        nID,
-			Description: req.Description,
+			Description: &req.Description,
 			Tags:        req.Tags,
 		}
 		saved, err := svc.CreateAgentGroup(c, req.token, group)
@@ -41,7 +41,7 @@ func addAgentGroupEndpoint(svc fleet.Service) endpoint.Endpoint {
 		res := agentGroupRes{
 			ID:             saved.ID,
 			Name:           saved.Name.String(),
-			Description:    saved.Description,
+			Description:    *saved.Description,
 			Tags:           saved.Tags,
 			MatchingAgents: saved.MatchingAgents,
 			created:        true,
@@ -64,7 +64,7 @@ func viewAgentGroupEndpoint(svc fleet.Service) endpoint.Endpoint {
 		res := agentGroupRes{
 			ID:             agentGroup.ID,
 			Name:           agentGroup.Name.String(),
-			Description:    agentGroup.Description,
+			Description:    *agentGroup.Description,
 			Tags:           agentGroup.Tags,
 			TsCreated:      agentGroup.Created,
 			MatchingAgents: agentGroup.MatchingAgents,
@@ -99,7 +99,7 @@ func listAgentGroupsEndpoint(svc fleet.Service) endpoint.Endpoint {
 			view := agentGroupRes{
 				ID:             ag.ID,
 				Name:           ag.Name.String(),
-				Description:    ag.Description,
+				Description:    *ag.Description,
 				Tags:           ag.Tags,
 				TsCreated:      ag.Created,
 				MatchingAgents: ag.MatchingAgents,
@@ -139,7 +139,7 @@ func editAgentGroupEndpoint(svc fleet.Service) endpoint.Endpoint {
 		res := agentGroupRes{
 			ID:             data.ID,
 			Name:           data.Name.String(),
-			Description:    data.Description,
+			Description:    *data.Description,
 			Tags:           data.Tags,
 			TsCreated:      data.Created,
 			MatchingAgents: data.MatchingAgents,

--- a/fleet/api/http/endpoint_test.go
+++ b/fleet/api/http/endpoint_test.go
@@ -54,7 +54,7 @@ var (
 		ID:          "",
 		MFOwnerID:   "",
 		Name:        types.Identifier{},
-		Description: "",
+		Description: nil,
 		MFChannelID: "",
 		Tags:        nil,
 		Created:     time.Time{},
@@ -300,7 +300,7 @@ func TestListAgentGroup(t *testing.T) {
 		data = append(data, agentGroupRes{
 			ID:             ag.ID,
 			Name:           ag.Name.String(),
-			Description:    ag.Description,
+			Description:    *ag.Description,
 			Tags:           ag.Tags,
 			TsCreated:      ag.Created,
 			MatchingAgents: nil,
@@ -479,7 +479,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 		"update existing agent group": {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
-				Description: ag.Description,
+				Description: *ag.Description,
 				Tags:        ag.Tags,
 			}),
 			id:          ag.ID,
@@ -497,7 +497,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 		"update agent group with a invalid id": {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
-				Description: ag.Description,
+				Description: *ag.Description,
 				Tags:        ag.Tags,
 			}),
 			id:          "invalid",
@@ -508,7 +508,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 		"update non-existing agent group": {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
-				Description: ag.Description,
+				Description: *ag.Description,
 				Tags:        ag.Tags,
 			}),
 			id:          wrongID,
@@ -519,7 +519,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 		"update agent group with invalid user token": {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
-				Description: ag.Description,
+				Description: *ag.Description,
 				Tags:        ag.Tags,
 			}),
 			id:          ag.ID,
@@ -530,7 +530,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 		"update agent group with empty user token": {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
-				Description: ag.Description,
+				Description: *ag.Description,
 				Tags:        ag.Tags,
 			}),
 			id:          ag.ID,
@@ -541,7 +541,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 		"update agent group with invalid content type": {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
-				Description: ag.Description,
+				Description: *ag.Description,
 				Tags:        ag.Tags,
 			}),
 			id:          ag.ID,
@@ -552,7 +552,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 		"update agent group without content type": {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
-				Description: ag.Description,
+				Description: *ag.Description,
 				Tags:        ag.Tags,
 			}),
 			id:          ag.ID,
@@ -584,7 +584,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 		"add a agent group with invalid name": {
 			req: toJSON(updateAgentGroupReq{
 				Name:        "g",
-				Description: ag.Description,
+				Description: *ag.Description,
 				Tags:        ag.Tags,
 			}),
 			id:          ag.ID,
@@ -595,17 +595,17 @@ func TestUpdateAgentGroup(t *testing.T) {
 		"update existing agent group with empty tags": {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
-				Description: ag.Description,
+				Description: *ag.Description,
 				Tags:        map[string]string{},
 			}),
 			id:          ag.ID,
 			contentType: contentType,
 			auth:        token,
-			status:      http.StatusBadRequest,
+			status:      http.StatusOK,
 		},
 		"update existing agent group with omitted name": {
 			req: toJSON(updateAgentGroupReq{
-				Description: ag.Description,
+				Description: *ag.Description,
 				Tags:        ag.Tags,
 			}),
 			id:          ag.ID,
@@ -616,7 +616,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 		"update existing agent group with omitted tags": {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
-				Description: ag.Description,
+				Description: *ag.Description,
 			}),
 			id:          ag.ID,
 			contentType: contentType,
@@ -1634,6 +1634,9 @@ func createAgentGroup(t *testing.T, name string, cli *clientServer) (fleet.Agent
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 	agCopy.Name = validName
 	agCopy.Tags = tags
+
+	description := "description example"
+	agCopy.Description = &description
 	ag, err := cli.service.CreateAgentGroup(context.Background(), token, agCopy)
 	if err != nil {
 		return fleet.AgentGroup{}, err

--- a/fleet/api/http/requests.go
+++ b/fleet/api/http/requests.go
@@ -54,7 +54,7 @@ type updateAgentGroupReq struct {
 	id          string
 	token       string
 	Name        string     `json:"name,omitempty"`
-	Description string     `json:"description,omitempty"`
+	Description *string    `json:"description,omitempty"`
 	Tags        types.Tags `json:"tags"`
 }
 
@@ -63,12 +63,7 @@ func (req updateAgentGroupReq) validate() error {
 	if req.token == "" {
 		return errors.ErrUnauthorizedAccess
 	}
-	if req.Name == "" && req.Tags == nil && req.Description == "" {
-		return errors.ErrMalformedEntity
-	}
-	if req.Tags == nil {
-		return nil
-	} else if len(req.Tags) == 0 {
+	if req.Name == "" && req.Tags == nil && req.Description == nil {
 		return errors.ErrMalformedEntity
 	}
 

--- a/fleet/comms_test.go
+++ b/fleet/comms_test.go
@@ -590,14 +590,13 @@ input:
 kind: collection`
 
 	policy := policies.Policy{
-		Name:        validName,
-		MFOwnerID:   ID.String(),
-		Description: "An example policy",
-		Backend:     "pktvisor",
-		Version:     0,
-		OrbTags:     map[string]string{"region": "eu"},
-		PolicyData:  policy_data,
-		Format:      "yaml",
+		Name:       validName,
+		MFOwnerID:  ID.String(),
+		Backend:    "pktvisor",
+		Version:    0,
+		OrbTags:    map[string]string{"region": "eu"},
+		PolicyData: policy_data,
+		Format:     "yaml",
 	}
 	res, err := svc.AddPolicy(context.Background(), token, policy)
 	require.Nil(t, err, fmt.Sprintf("Unexpected error: %s", err))

--- a/fleet/postgres/agent_groups.go
+++ b/fleet/postgres/agent_groups.go
@@ -385,10 +385,17 @@ type dbMatchingGroups struct {
 
 func toDBAgentGroup(group fleet.AgentGroup) (dbAgentGroup, error) {
 
+	var description string
+	if group.Description == nil {
+		description = ""
+	} else {
+		description = *group.Description
+	}
+
 	return dbAgentGroup{
 		ID:          group.ID,
 		Name:        group.Name,
-		Description: group.Description,
+		Description: description,
 		MFOwnerID:   group.MFOwnerID,
 		MFChannelID: group.MFChannelID,
 		Tags:        db.Tags(group.Tags),
@@ -400,7 +407,7 @@ func toAgentGroup(dba dbAgentGroup) (fleet.AgentGroup, error) {
 	return fleet.AgentGroup{
 		ID:             dba.ID,
 		Name:           dba.Name,
-		Description:    dba.Description,
+		Description:    &dba.Description,
 		MFOwnerID:      dba.MFOwnerID,
 		MFChannelID:    dba.MFChannelID,
 		Created:        dba.Created,

--- a/fleet/postgres/agent_groups_test.go
+++ b/fleet/postgres/agent_groups_test.go
@@ -21,6 +21,10 @@ import (
 	"testing"
 )
 
+var (
+	description = "example description"
+)
+
 func TestAgentGroupSave(t *testing.T) {
 	dbMiddleware := postgres.NewDatabase(db)
 	agentGroupRepository := postgres.NewAgentGroupRepository(dbMiddleware, logger)
@@ -95,7 +99,7 @@ func TestAgentGroupRetrieve(t *testing.T) {
 
 	group := fleet.AgentGroup{
 		Name:        nameID,
-		Description: "a example",
+		Description: &description,
 		MFOwnerID:   oID.String(),
 		MFChannelID: chID.String(),
 		Tags:        types.Tags{"testkey": "testvalue"},
@@ -168,7 +172,7 @@ func TestMultiAgentGroupRetrieval(t *testing.T) {
 
 		group := fleet.AgentGroup{
 			Name:        nameID,
-			Description: "a example",
+			Description: &description,
 			MFOwnerID:   oID.String(),
 			MFChannelID: chID.String(),
 			Tags:        types.Tags{"testkey": "testvalue"},
@@ -466,7 +470,7 @@ func TestAgentGroupRetrieveAllByAgent(t *testing.T) {
 
 		group := fleet.AgentGroup{
 			Name:        nameID,
-			Description: "a example",
+			Description: &description,
 			MFOwnerID:   oID.String(),
 			MFChannelID: chID.String(),
 			Tags:        types.Tags{"testkey": "testvalue"},
@@ -548,7 +552,7 @@ func TestRetrieveMatchingGroups(t *testing.T) {
 
 		group := fleet.AgentGroup{
 			Name:        nameID,
-			Description: "a example",
+			Description: &description,
 			MFOwnerID:   oID.String(),
 			MFChannelID: chID.String(),
 			Tags:        types.Tags{"testkey": "testvalue"},

--- a/policies/api/http/endpoint.go
+++ b/policies/api/http/endpoint.go
@@ -34,7 +34,7 @@ func addPolicyEndpoint(svc policies.Service) endpoint.Endpoint {
 			Backend:       req.Backend,
 			SchemaVersion: req.SchemaVersion,
 			Policy:        req.Policy,
-			Description:   req.Description,
+			Description:   &req.Description,
 			OrbTags:       req.Tags,
 			PolicyData:    req.PolicyData,
 			Format:        req.Format,
@@ -51,7 +51,7 @@ func addPolicyEndpoint(svc policies.Service) endpoint.Endpoint {
 		res := policyRes{
 			ID:            saved.ID,
 			Name:          saved.Name.String(),
-			Description:   saved.Description,
+			Description:   *saved.Description,
 			Tags:          saved.OrbTags,
 			Backend:       saved.Backend,
 			SchemaVersion: saved.SchemaVersion,
@@ -80,7 +80,7 @@ func viewPolicyEndpoint(svc policies.Service) endpoint.Endpoint {
 		res := policyRes{
 			ID:            policy.ID,
 			Name:          policy.Name.String(),
-			Description:   policy.Description,
+			Description:   *policy.Description,
 			Tags:          policy.OrbTags,
 			Backend:       policy.Backend,
 			SchemaVersion: policy.SchemaVersion,
@@ -121,7 +121,7 @@ func listPoliciesEndpoint(svc policies.Service) endpoint.Endpoint {
 			view := policyRes{
 				ID:            ag.ID,
 				Name:          ag.Name.String(),
-				Description:   ag.Description,
+				Description:   *ag.Description,
 				Version:       ag.Version,
 				Backend:       ag.Backend,
 				SchemaVersion: ag.SchemaVersion,
@@ -167,7 +167,7 @@ func editPoliciyEndpoint(svc policies.Service) endpoint.Endpoint {
 		plcyRes := policyUpdateRes{
 			ID:          res.ID,
 			Name:        res.Name.String(),
-			Description: res.Description,
+			Description: *res.Description,
 			Tags:        res.OrbTags,
 			Policy:      res.Policy,
 			Format:      res.Format,
@@ -295,7 +295,7 @@ func validatePolicyEndpoint(svc policies.Service) endpoint.Endpoint {
 			Backend:     req.Backend,
 			Policy:      req.Policy,
 			OrbTags:     req.Tags,
-			Description: req.Description,
+			Description: &req.Description,
 			Format:      req.Format,
 			PolicyData:  req.PolicyData,
 		}
@@ -312,7 +312,7 @@ func validatePolicyEndpoint(svc policies.Service) endpoint.Endpoint {
 			Policy:      validated.Policy,
 			PolicyData:  validated.PolicyData,
 			Format:      validated.Format,
-			Description: validated.Description,
+			Description: *validated.Description,
 		}
 
 		return res, nil
@@ -449,7 +449,7 @@ func duplicatePolicyEndpoint(svc policies.Service) endpoint.Endpoint {
 		res := policyRes{
 			ID:            duplicatedPolicy.ID,
 			Name:          duplicatedPolicy.Name.String(),
-			Description:   duplicatedPolicy.Description,
+			Description:   *duplicatedPolicy.Description,
 			Tags:          duplicatedPolicy.OrbTags,
 			Backend:       duplicatedPolicy.Backend,
 			SchemaVersion: duplicatedPolicy.SchemaVersion,

--- a/policies/api/http/endpoint_test.go
+++ b/policies/api/http/endpoint_test.go
@@ -467,6 +467,17 @@ func TestPolicyEdition(t *testing.T) {
 				Name: "mypktvisorpolicyyaml-3",
 			}),
 		},
+		"update just tags of an existing policy": {
+			id:          policyTestAttributeDeletion.ID,
+			contentType: "application/json",
+			auth:        token,
+			status:      http.StatusOK,
+			data: toJSON(updatePolicyReq{
+				Tags: types.Tags{
+					"test": "tags",
+				},
+			}),
+		},
 	}
 
 	for desc, tc := range cases {

--- a/policies/api/http/requests.go
+++ b/policies/api/http/requests.go
@@ -90,7 +90,7 @@ type updatePolicyReq struct {
 	id          string
 	token       string
 	Name        string         `json:"name,omitempty"`
-	Description string         `json:"description,omitempty"`
+	Description *string        `json:"description,omitempty"`
 	Tags        types.Tags     `json:"tags,omitempty"`
 	Format      string         `json:"format,omitempty"`
 	Policy      types.Metadata `json:"policy,omitempty"`
@@ -103,7 +103,7 @@ func (req updatePolicyReq) validate() error {
 		return errors.ErrUnauthorizedAccess
 	}
 
-	if (req.Name == "" && req.Description == "") && (req.PolicyData == "" && req.Policy == nil) {
+	if (req.Name == "" && req.Description == nil && req.Tags == nil) && (req.PolicyData == "" && req.Policy == nil) {
 		return errors.ErrMalformedEntity
 	}
 

--- a/policies/mocks/policies.go
+++ b/policies/mocks/policies.go
@@ -222,6 +222,11 @@ func (m *mockPoliciesRepository) SavePolicy(ctx context.Context, policy policies
 		}
 	}
 
+	if policy.Description == nil {
+		description := ""
+		policy.Description = &description
+	}
+
 	ID, _ := uuid.NewV4()
 	policy.ID = ID.String()
 	m.pdb[policy.ID] = policy

--- a/policies/policies.go
+++ b/policies/policies.go
@@ -14,7 +14,7 @@ import (
 type Policy struct {
 	ID            string
 	Name          types.Identifier
-	Description   string
+	Description   *string
 	MFOwnerID     string
 	Backend       string
 	SchemaVersion string

--- a/policies/policy_service.go
+++ b/policies/policy_service.go
@@ -158,6 +158,10 @@ func (s policiesService) EditPolicy(ctx context.Context, token string, pol Polic
 		pol.Name = currentPol.Name
 	}
 
+	if pol.Description == nil {
+		pol.Description = currentPol.Description
+	}
+
 	pol.Version++
 	err = s.repo.UpdatePolicy(ctx, ownerID, pol)
 	if err != nil {

--- a/policies/policy_service.go
+++ b/policies/policy_service.go
@@ -162,6 +162,10 @@ func (s policiesService) EditPolicy(ctx context.Context, token string, pol Polic
 		pol.Description = currentPol.Description
 	}
 
+	if pol.OrbTags == nil {
+		pol.OrbTags = currentPol.OrbTags
+	}
+
 	pol.Version++
 	err = s.repo.UpdatePolicy(ctx, ownerID, pol)
 	if err != nil {

--- a/policies/policy_service_test.go
+++ b/policies/policy_service_test.go
@@ -332,6 +332,31 @@ func TestEditPolicy(t *testing.T) {
 			token: token,
 			err:   nil,
 		},
+		"update a existing policy with empty tags": {
+			policy: policies.Policy{
+				ID:      policy.ID,
+				OrbTags: types.Tags{},
+			},
+			expectedPolicy: policies.Policy{
+				Name:        policy.Name,
+				OrbTags:     types.Tags{},
+				Description: policy.Description,
+			},
+			token: token,
+			err:   nil,
+		},
+		"update a existing policy with omitted tags": {
+			policy: policies.Policy{
+				ID: policyTestDescriptionAttribute.ID,
+			},
+			expectedPolicy: policies.Policy{
+				Name:        policyTestDescriptionAttribute.Name,
+				OrbTags:     policyTestDescriptionAttribute.OrbTags,
+				Description: policyTestDescriptionAttribute.Description,
+			},
+			token: token,
+			err:   nil,
+		},
 	}
 
 	for desc, tc := range cases {
@@ -340,6 +365,7 @@ func TestEditPolicy(t *testing.T) {
 			if err == nil {
 				assert.Equal(t, tc.expectedPolicy.Name.String(), res.Name.String(), fmt.Sprintf("%s: expected name %s got %s", desc, tc.expectedPolicy.Name.String(), res.Name.String()))
 				assert.Equal(t, *tc.expectedPolicy.Description, *res.Description, fmt.Sprintf("%s: expected name %s got %s", desc, *tc.expectedPolicy.Description, *res.Description))
+				assert.Equal(t, tc.expectedPolicy.OrbTags, res.OrbTags, fmt.Sprintf("%s: expected name %s got %s", desc, tc.expectedPolicy.OrbTags, res.OrbTags))
 			}
 			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected error %d got %d", desc, tc.err, err))
 		})
@@ -1208,6 +1234,9 @@ func createPolicy(t *testing.T, svc policies.Service, name string) policies.Poli
 		Format:      format,
 		PolicyData:  policy_data,
 		Description: &description,
+		OrbTags: types.Tags{
+			"test": "tags",
+		},
 	}
 
 	res, err := svc.AddPolicy(context.Background(), token, policy)

--- a/policies/policy_service_test.go
+++ b/policies/policy_service_test.go
@@ -192,6 +192,7 @@ func TestEditPolicy(t *testing.T) {
 	policy := createPolicy(t, svc, "policy")
 	policyTestDescriptionAttribute := createPolicy(t, svc, "policyDescription")
 	policyTestTagsAttribute := createPolicy(t, svc, "policyTags")
+	policyTestTagsAttributeDeletion := createPolicy(t, svc, "policyTags2")
 
 	nameID, err := types.NewIdentifier("new-policy")
 	require.Nil(t, err, fmt.Sprintf("Unexpected error: %s", err))
@@ -230,6 +231,7 @@ func TestEditPolicy(t *testing.T) {
 				PolicyData:  policy_data,
 				Format:      format,
 				Description: &newDescription,
+				OrbTags:     policy.OrbTags,
 			},
 			token: token,
 			err:   nil,
@@ -291,12 +293,12 @@ func TestEditPolicy(t *testing.T) {
 		"update a existing policy with omitted description": {
 			policy: policies.Policy{
 				ID:        policyTestDescriptionAttribute.ID,
-				Name:      nameID,
 				MFOwnerID: policy.MFOwnerID,
 			},
 			expectedPolicy: policies.Policy{
-				Name:        nameID,
+				Name:        policyTestDescriptionAttribute.Name,
 				Description: policyTestDescriptionAttribute.Description,
+				OrbTags:     policyTestDescriptionAttribute.OrbTags,
 			},
 			token: token,
 			err:   nil,
@@ -311,6 +313,7 @@ func TestEditPolicy(t *testing.T) {
 			expectedPolicy: policies.Policy{
 				Name:        nameID,
 				Description: &emptyDescription,
+				OrbTags:     policy.OrbTags,
 			},
 			token: token,
 			err:   nil,
@@ -334,13 +337,13 @@ func TestEditPolicy(t *testing.T) {
 		},
 		"update a existing policy with empty tags": {
 			policy: policies.Policy{
-				ID:      policy.ID,
+				ID:      policyTestTagsAttributeDeletion.ID,
 				OrbTags: types.Tags{},
 			},
 			expectedPolicy: policies.Policy{
-				Name:        policy.Name,
+				Name:        policyTestTagsAttributeDeletion.Name,
 				OrbTags:     types.Tags{},
-				Description: policy.Description,
+				Description: policyTestTagsAttributeDeletion.Description,
 			},
 			token: token,
 			err:   nil,
@@ -364,8 +367,8 @@ func TestEditPolicy(t *testing.T) {
 			res, err := svc.EditPolicy(context.Background(), tc.token, tc.policy)
 			if err == nil {
 				assert.Equal(t, tc.expectedPolicy.Name.String(), res.Name.String(), fmt.Sprintf("%s: expected name %s got %s", desc, tc.expectedPolicy.Name.String(), res.Name.String()))
-				assert.Equal(t, *tc.expectedPolicy.Description, *res.Description, fmt.Sprintf("%s: expected name %s got %s", desc, *tc.expectedPolicy.Description, *res.Description))
-				assert.Equal(t, tc.expectedPolicy.OrbTags, res.OrbTags, fmt.Sprintf("%s: expected name %s got %s", desc, tc.expectedPolicy.OrbTags, res.OrbTags))
+				assert.Equal(t, *tc.expectedPolicy.Description, *res.Description, fmt.Sprintf("%s: expected description %s got %s", desc, *tc.expectedPolicy.Description, *res.Description))
+				assert.Equal(t, tc.expectedPolicy.OrbTags, res.OrbTags, fmt.Sprintf("%s: expected tags %s got %s", desc, tc.expectedPolicy.OrbTags, res.OrbTags))
 			}
 			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected error %d got %d", desc, tc.err, err))
 		})

--- a/policies/policy_service_test.go
+++ b/policies/policy_service_test.go
@@ -190,7 +190,8 @@ func TestEditPolicy(t *testing.T) {
 	svc := newService(users)
 
 	policy := createPolicy(t, svc, "policy")
-	policyTestDescription := createPolicy(t, svc, "policyDescription")
+	policyTestDescriptionAttribute := createPolicy(t, svc, "policyDescription")
+	policyTestTagsAttribute := createPolicy(t, svc, "policyTags")
 
 	nameID, err := types.NewIdentifier("new-policy")
 	require.Nil(t, err, fmt.Sprintf("Unexpected error: %s", err))
@@ -289,13 +290,13 @@ func TestEditPolicy(t *testing.T) {
 		},
 		"update a existing policy with omitted description": {
 			policy: policies.Policy{
-				ID:        policyTestDescription.ID,
+				ID:        policyTestDescriptionAttribute.ID,
 				Name:      nameID,
 				MFOwnerID: policy.MFOwnerID,
 			},
 			expectedPolicy: policies.Policy{
 				Name:        nameID,
-				Description: policyTestDescription.Description,
+				Description: policyTestDescriptionAttribute.Description,
 			},
 			token: token,
 			err:   nil,
@@ -310,6 +311,23 @@ func TestEditPolicy(t *testing.T) {
 			expectedPolicy: policies.Policy{
 				Name:        nameID,
 				Description: &emptyDescription,
+			},
+			token: token,
+			err:   nil,
+		},
+		"update just tags of na existing policy": {
+			policy: policies.Policy{
+				ID: policyTestTagsAttribute.ID,
+				OrbTags: types.Tags{
+					"tags": "true",
+				},
+			},
+			expectedPolicy: policies.Policy{
+				Name: policyTestTagsAttribute.Name,
+				OrbTags: types.Tags{
+					"tags": "true",
+				},
+				Description: policyTestTagsAttribute.Description,
 			},
 			token: token,
 			err:   nil,

--- a/policies/policy_service_test.go
+++ b/policies/policy_service_test.go
@@ -190,6 +190,7 @@ func TestEditPolicy(t *testing.T) {
 	svc := newService(users)
 
 	policy := createPolicy(t, svc, "policy")
+	policyTestDescription := createPolicy(t, svc, "policyDescription")
 
 	nameID, err := types.NewIdentifier("new-policy")
 	require.Nil(t, err, fmt.Sprintf("Unexpected error: %s", err))
@@ -197,7 +198,6 @@ func TestEditPolicy(t *testing.T) {
 	wrongOwnerID, err := uuid.NewV4()
 	require.Nil(t, err, fmt.Sprintf("Unexpected error: %s", err))
 
-	wrongPolicy := policies.Policy{MFOwnerID: wrongOwnerID.String()}
 	newPolicy := policies.Policy{
 		ID:         policy.ID,
 		Name:       nameID,
@@ -206,65 +206,122 @@ func TestEditPolicy(t *testing.T) {
 		Format:     format,
 	}
 
-	invalidFormatPolicy := newPolicy
-	invalidFormatPolicy.Format = "invalid"
-
-	invalidPolicyData := newPolicy
-	invalidPolicyData.PolicyData = "invalid"
-
-	invalidYamlPolicy := newPolicy
-	invalidYamlPolicy.Format = ""
-
-	invalidJsonPolicy := newPolicy
-	invalidJsonPolicy.Format = "json"
+	emptyDescription := ""
+	newDescription := "new description"
 
 	cases := map[string]struct {
-		pol   policies.Policy
-		token string
-		err   error
+		policy         policies.Policy
+		expectedPolicy policies.Policy
+		token          string
+		err            error
 	}{
 		"update a existing policy": {
-			pol:   newPolicy,
+			policy: policies.Policy{
+				ID:          policy.ID,
+				Name:        nameID,
+				MFOwnerID:   policy.MFOwnerID,
+				PolicyData:  policy_data,
+				Format:      format,
+				Description: &newDescription,
+			},
+			expectedPolicy: policies.Policy{
+				Name:        nameID,
+				PolicyData:  policy_data,
+				Format:      format,
+				Description: &newDescription,
+			},
 			token: token,
 			err:   nil,
 		},
 		"update policy with wrong credentials": {
-			pol:   newPolicy,
-			token: "invalidToken",
-			err:   policies.ErrUnauthorizedAccess,
+			policy: newPolicy,
+			token:  "invalidToken",
+			err:    policies.ErrUnauthorizedAccess,
 		},
 		"update a non-existing policy": {
-			pol:   wrongPolicy,
-			token: token,
-			err:   policies.ErrNotFound,
+			policy: policies.Policy{MFOwnerID: wrongOwnerID.String()},
+			token:  token,
+			err:    policies.ErrNotFound,
 		},
 		"update a existing policy with invalid format": {
-			pol:   invalidFormatPolicy,
+			policy: policies.Policy{
+				ID:         policy.ID,
+				Name:       nameID,
+				MFOwnerID:  policy.MFOwnerID,
+				PolicyData: policy_data,
+				Format:     "invalid",
+			},
 			token: token,
 			err:   policies.ErrValidatePolicy,
 		},
 		"update a existing policy with invalid policy_data": {
-			pol:   invalidPolicyData,
+			policy: policies.Policy{
+				ID:         policy.ID,
+				Name:       nameID,
+				MFOwnerID:  policy.MFOwnerID,
+				PolicyData: "invalid",
+				Format:     format,
+			},
 			token: token,
 			err:   policies.ErrValidatePolicy,
 		},
 		"update a policy with invalid yaml - empty Format field": {
-			pol:   invalidYamlPolicy,
+			policy: policies.Policy{
+				ID:         policy.ID,
+				Name:       nameID,
+				MFOwnerID:  policy.MFOwnerID,
+				PolicyData: policy_data,
+				Format:     "",
+			},
 			token: token,
 			err:   policies.ErrValidatePolicy,
 		},
 		"update a policy with invalid json - not empty Format field": {
-			pol:   invalidJsonPolicy,
+			policy: policies.Policy{
+				ID:         policy.ID,
+				Name:       nameID,
+				MFOwnerID:  policy.MFOwnerID,
+				PolicyData: policy_data,
+				Format:     "json",
+			},
 			token: token,
 			err:   policies.ErrValidatePolicy,
+		},
+		"update a existing policy with omitted description": {
+			policy: policies.Policy{
+				ID:        policyTestDescription.ID,
+				Name:      nameID,
+				MFOwnerID: policy.MFOwnerID,
+			},
+			expectedPolicy: policies.Policy{
+				Name:        nameID,
+				Description: policyTestDescription.Description,
+			},
+			token: token,
+			err:   nil,
+		},
+		"update a existing policy with empty description": {
+			policy: policies.Policy{
+				ID:          policy.ID,
+				Name:        nameID,
+				MFOwnerID:   policy.MFOwnerID,
+				Description: &emptyDescription,
+			},
+			expectedPolicy: policies.Policy{
+				Name:        nameID,
+				Description: &emptyDescription,
+			},
+			token: token,
+			err:   nil,
 		},
 	}
 
 	for desc, tc := range cases {
 		t.Run(desc, func(t *testing.T) {
-			res, err := svc.EditPolicy(context.Background(), tc.token, tc.pol)
+			res, err := svc.EditPolicy(context.Background(), tc.token, tc.policy)
 			if err == nil {
-				assert.Equal(t, tc.pol.Name.String(), res.Name.String(), fmt.Sprintf("%s: expected name %s got %s", desc, tc.pol.Name.String(), res.Name.String()))
+				assert.Equal(t, tc.expectedPolicy.Name.String(), res.Name.String(), fmt.Sprintf("%s: expected name %s got %s", desc, tc.expectedPolicy.Name.String(), res.Name.String()))
+				assert.Equal(t, *tc.expectedPolicy.Description, *res.Description, fmt.Sprintf("%s: expected name %s got %s", desc, *tc.expectedPolicy.Description, *res.Description))
 			}
 			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected error %d got %d", desc, tc.err, err))
 		})
@@ -363,10 +420,11 @@ func TestCreatePolicy(t *testing.T) {
 	nameID, _ := types.NewIdentifier("my-policy")
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
+	description := "An example policy"
 	policy := policies.Policy{
 		Name:        nameID,
 		MFOwnerID:   ownerID.String(),
-		Description: "An example policy",
+		Description: &description,
 		Backend:     "pktvisor",
 		Version:     0,
 		OrbTags:     map[string]string{"region": "eu"},
@@ -1124,12 +1182,14 @@ func createPolicy(t *testing.T, svc policies.Service, name string) policies.Poli
 	validName, err := types.NewIdentifier(name)
 	require.Nil(t, err, fmt.Sprintf("Unexpected error: %s", err))
 
+	description := "example policy"
 	policy := policies.Policy{
-		ID:         ID.String(),
-		Name:       validName,
-		Backend:    "pktvisor",
-		Format:     format,
-		PolicyData: policy_data,
+		ID:          ID.String(),
+		Name:        validName,
+		Backend:     "pktvisor",
+		Format:      format,
+		PolicyData:  policy_data,
+		Description: &description,
 	}
 
 	res, err := svc.AddPolicy(context.Background(), token, policy)

--- a/policies/postgres/policies.go
+++ b/policies/postgres/policies.go
@@ -720,10 +720,17 @@ func toDBPolicy(policy policies.Policy) (dbPolicy, error) {
 		return dbPolicy{}, errors.Wrap(errors.ErrMalformedEntity, err)
 	}
 
+	var description string
+	if policy.Description == nil {
+		description = ""
+	} else {
+		description = *policy.Description
+	}
+
 	return dbPolicy{
 		ID:            policy.ID,
 		Name:          policy.Name,
-		Description:   policy.Description,
+		Description:   description,
 		Version:       policy.Version,
 		MFOwnerID:     uID.String(),
 		Backend:       policy.Backend,
@@ -794,7 +801,7 @@ func toPolicy(dba dbPolicy) policies.Policy {
 	policy := policies.Policy{
 		ID:            dba.ID,
 		Name:          dba.Name,
-		Description:   dba.Description,
+		Description:   &dba.Description,
 		MFOwnerID:     dba.MFOwnerID,
 		Backend:       dba.Backend,
 		SchemaVersion: dba.SchemaVersion,

--- a/sinks/api/grpc/endpoint.go
+++ b/sinks/api/grpc/endpoint.go
@@ -34,7 +34,7 @@ func retrieveSinkEndpoint(svc sinks.SinkService) endpoint.Endpoint {
 		res := sinkRes{
 			id:          sink.ID,
 			name:        sink.Name.String(),
-			description: sink.Description,
+			description: *sink.Description,
 			tags:        tagData,
 			state:       sink.State.String(),
 			error:       sink.Error,
@@ -82,7 +82,7 @@ func buildSinkResponse(sink sinks.Sink) (sinkRes, error) {
 	return sinkRes{
 		id:          sink.ID,
 		name:        sink.Name.String(),
-		description: sink.Description,
+		description: *sink.Description,
 		tags:        tagData,
 		state:       sink.State.String(),
 		error:       sink.Error,

--- a/sinks/api/http/endpoint.go
+++ b/sinks/api/http/endpoint.go
@@ -49,7 +49,7 @@ func addEndpoint(svc sinks.SinkService) endpoint.Endpoint {
 			Name:        nID,
 			Backend:     req.Backend,
 			Config:      req.Config,
-			Description: req.Description,
+			Description: &req.Description,
 			Tags:        req.Tags,
 		}
 		saved, err := svc.CreateSink(ctx, req.token, sink)
@@ -60,7 +60,7 @@ func addEndpoint(svc sinks.SinkService) endpoint.Endpoint {
 		res := sinkRes{
 			ID:          saved.ID,
 			Name:        saved.Name.String(),
-			Description: saved.Description,
+			Description: *saved.Description,
 			Tags:        saved.Tags,
 			State:       saved.State.String(),
 			Error:       saved.Error,
@@ -102,7 +102,7 @@ func updateSinkEndpoint(svc sinks.SinkService) endpoint.Endpoint {
 		res := sinkRes{
 			ID:          sinkEdited.ID,
 			Name:        sinkEdited.Name.String(),
-			Description: sinkEdited.Description,
+			Description: *sinkEdited.Description,
 			Tags:        sinkEdited.Tags,
 			State:       sinkEdited.State.String(),
 			Error:       sinkEdited.Error,
@@ -140,15 +140,17 @@ func listSinksEndpoint(svc sinks.SinkService) endpoint.Endpoint {
 
 		for _, sink := range page.Sinks {
 			view := sinkRes{
-				ID:          sink.ID,
-				Name:        sink.Name.String(),
-				Description: sink.Description,
-				Tags:        sink.Tags,
-				State:       sink.State.String(),
-				Error:       sink.Error,
-				Backend:     sink.Backend,
-				Config:      omitSecretInformation(sink.Config),
-				TsCreated:   sink.Created,
+				ID:        sink.ID,
+				Name:      sink.Name.String(),
+				Tags:      sink.Tags,
+				State:     sink.State.String(),
+				Error:     sink.Error,
+				Backend:   sink.Backend,
+				Config:    omitSecretInformation(sink.Config),
+				TsCreated: sink.Created,
+			}
+			if sink.Description != nil {
+				view.Description = *sink.Description
 			}
 			res.Sinks = append(res.Sinks, view)
 		}
@@ -218,7 +220,7 @@ func viewSinkEndpoint(svc sinks.SinkService) endpoint.Endpoint {
 		res := sinkRes{
 			ID:          sink.ID,
 			Name:        sink.Name.String(),
-			Description: sink.Description,
+			Description: *sink.Description,
 			Tags:        sink.Tags,
 			State:       sink.State.String(),
 			Error:       sink.Error,
@@ -226,6 +228,10 @@ func viewSinkEndpoint(svc sinks.SinkService) endpoint.Endpoint {
 			Config:      omitSecretInformation(sink.Config),
 			TsCreated:   sink.Created,
 		}
+		if sink.Description != nil {
+			res.Description = *sink.Description
+		}
+
 		return res, err
 	}
 }
@@ -263,7 +269,7 @@ func validateSinkEndpoint(svc sinks.SinkService) endpoint.Endpoint {
 			Name:        nID,
 			Backend:     req.Backend,
 			Config:      req.Config,
-			Description: req.Description,
+			Description: &req.Description,
 			Tags:        req.Tags,
 		}
 
@@ -275,7 +281,7 @@ func validateSinkEndpoint(svc sinks.SinkService) endpoint.Endpoint {
 		res := validateSinkRes{
 			ID:          validated.ID,
 			Name:        validated.Name.String(),
-			Description: validated.Description,
+			Description: *validated.Description,
 			Tags:        validated.Tags,
 			State:       validated.State.String(),
 			Error:       validated.Error,

--- a/sinks/api/http/endpoint_test.go
+++ b/sinks/api/http/endpoint_test.go
@@ -40,10 +40,11 @@ const (
 )
 
 var (
-	nameID, _ = types.NewIdentifier("my-sink")
-	sink      = sinks.Sink{
+	nameID, _   = types.NewIdentifier("my-sink")
+	description = "An example prometheus sink"
+	sink        = sinks.Sink{
 		Name:        nameID,
-		Description: "An example prometheus sink",
+		Description: &description,
 		Backend:     "prometheus",
 		Config:      map[string]interface{}{"remote_host": "data", "username": "dbuser"},
 		Tags:        map[string]string{"cloud": "aws"},
@@ -254,13 +255,6 @@ func TestUpdateSink(t *testing.T) {
 	sk, err := service.CreateSink(context.Background(), token, sink)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
-	data := toJSON(updateSinkReq{
-		Name:        sk.Name.String(),
-		Description: sk.Description,
-		Config:      sink.Config,
-		Tags:        sk.Tags,
-	})
-
 	dataInvalidName := toJSON(updateSinkReq{
 		Name:        invalidName,
 		Description: sk.Description,
@@ -283,7 +277,12 @@ func TestUpdateSink(t *testing.T) {
 		status      int
 	}{
 		"update existing sink": {
-			req:         data,
+			req: toJSON(updateSinkReq{
+				Name:        sk.Name.String(),
+				Description: sk.Description,
+				Config:      sink.Config,
+				Tags:        sk.Tags,
+			}),
 			id:          sk.ID,
 			contentType: contentType,
 			auth:        token,
@@ -297,42 +296,72 @@ func TestUpdateSink(t *testing.T) {
 			status:      http.StatusBadRequest,
 		},
 		"update sink with a invalid id": {
-			req:         data,
+			req: toJSON(updateSinkReq{
+				Name:        sk.Name.String(),
+				Description: sk.Description,
+				Config:      sink.Config,
+				Tags:        sk.Tags,
+			}),
 			id:          "invalid",
 			contentType: contentType,
 			auth:        token,
 			status:      http.StatusNotFound,
 		},
 		"update non-existing sink": {
-			req:         data,
+			req: toJSON(updateSinkReq{
+				Name:        sk.Name.String(),
+				Description: sk.Description,
+				Config:      sink.Config,
+				Tags:        sk.Tags,
+			}),
 			id:          wrongID.String(),
 			contentType: contentType,
 			auth:        token,
 			status:      http.StatusNotFound,
 		},
 		"update sink with invalid user token": {
-			req:         data,
+			req: toJSON(updateSinkReq{
+				Name:        sk.Name.String(),
+				Description: sk.Description,
+				Config:      sink.Config,
+				Tags:        sk.Tags,
+			}),
 			id:          sk.ID,
 			contentType: contentType,
 			auth:        "invalid",
 			status:      http.StatusUnauthorized,
 		},
 		"update sink with empty user token": {
-			req:         data,
+			req: toJSON(updateSinkReq{
+				Name:        sk.Name.String(),
+				Description: sk.Description,
+				Config:      sink.Config,
+				Tags:        sk.Tags,
+			}),
 			id:          sk.ID,
 			contentType: contentType,
 			auth:        "",
 			status:      http.StatusUnauthorized,
 		},
 		"update sink with invalid content type": {
-			req:         data,
+			req: toJSON(updateSinkReq{
+				Name:        sk.Name.String(),
+				Description: sk.Description,
+				Config:      sink.Config,
+				Tags:        sk.Tags,
+			}),
 			id:          sk.ID,
 			contentType: "invalid",
 			auth:        token,
 			status:      http.StatusUnsupportedMediaType,
 		},
 		"update sink without content type": {
-			req:         data,
+			req: toJSON(updateSinkReq{
+				Name:        sk.Name.String(),
+				Description: sk.Description,
+				Config:      sink.Config,
+				Tags:        sk.Tags,
+			}),
 			id:          sk.ID,
 			contentType: "",
 			auth:        token,
@@ -401,11 +430,10 @@ func TestListSinks(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		var skName, _ = types.NewIdentifier(fmt.Sprintf("name%d", i))
 		snk := sinks.Sink{
-			Name:        skName,
-			Description: "An example prometheus sink",
-			Backend:     "prometheus",
-			Config:      map[string]interface{}{"remote_host": "data", "username": "dbuser"},
-			Tags:        map[string]string{"cloud": "aws"},
+			Name:    skName,
+			Backend: "prometheus",
+			Config:  map[string]interface{}{"remote_host": "data", "username": "dbuser"},
+			Tags:    map[string]string{"cloud": "aws"},
 		}
 
 		sk, err := svc.CreateSink(context.Background(), token, snk)
@@ -743,7 +771,7 @@ func TestViewSink(t *testing.T) {
 	data := toJSON(sinkRes{
 		ID:          sk.ID,
 		Name:        sk.Name.String(),
-		Description: sk.Description,
+		Description: *sk.Description,
 		Backend:     sk.Backend,
 		Config:      sk.Config,
 		Tags:        sk.Tags,

--- a/sinks/api/http/requests.go
+++ b/sinks/api/http/requests.go
@@ -71,7 +71,7 @@ func (req addReq) validate() error {
 type updateSinkReq struct {
 	Name        string         `json:"name,omitempty"`
 	Config      types.Metadata `json:"config,omitempty"`
-	Description string         `json:"description,omitempty"`
+	Description *string        `json:"description,omitempty"`
 	Tags        types.Tags     `json:"tags,omitempty"`
 	id          string
 	token       string
@@ -86,7 +86,7 @@ func (req updateSinkReq) validate() error {
 		return errors.ErrMalformedEntity
 	}
 
-	if req.Description == "" && req.Name == "" && len(req.Config) == 0 && req.Tags == nil {
+	if req.Description == nil && req.Name == "" && len(req.Config) == 0 && req.Tags == nil {
 		return errors.ErrMalformedEntity
 	}
 

--- a/sinks/postgres/sinks.go
+++ b/sinks/postgres/sinks.go
@@ -310,13 +310,20 @@ func toDBSink(sink sinks.Sink) (dbSink, error) {
 		return dbSink{}, errors.Wrap(errors.ErrMalformedEntity, err)
 	}
 
+	var description string
+	if sink.Description == nil {
+		description = ""
+	} else {
+		description = *sink.Description
+	}
+
 	return dbSink{
 		ID:          sink.ID,
 		Name:        sink.Name,
 		MFOwnerID:   uID.String(),
 		Metadata:    db.Metadata(sink.Config),
 		Backend:     sink.Backend,
-		Description: sink.Description,
+		Description: description,
 		State:       sink.State,
 		Error:       sink.Error,
 		Tags:        db.Tags(sink.Tags),
@@ -330,7 +337,7 @@ func toSink(dba dbSink) (sinks.Sink, error) {
 		Name:        dba.Name,
 		MFOwnerID:   dba.MFOwnerID,
 		Backend:     dba.Backend,
-		Description: dba.Description,
+		Description: &dba.Description,
 		State:       dba.State,
 		Error:       dba.Error,
 		Config:      types.Metadata(dba.Metadata),

--- a/sinks/postgres/sinks_test.go
+++ b/sinks/postgres/sinks_test.go
@@ -24,7 +24,8 @@ import (
 )
 
 var (
-	logger, _ = zap.NewDevelopment()
+	logger, _   = zap.NewDevelopment()
+	description = "An example prometheus sink"
 )
 
 func TestSinkSave(t *testing.T) {
@@ -45,7 +46,7 @@ func TestSinkSave(t *testing.T) {
 
 	sink := sinks.Sink{
 		Name:        nameID,
-		Description: "An example prometheus sink",
+		Description: &description,
 		Backend:     "prometheus",
 		ID:          skID.String(),
 		Created:     time.Now(),
@@ -58,7 +59,7 @@ func TestSinkSave(t *testing.T) {
 
 	invalidOwnerSink := sinks.Sink{
 		Name:        nameID,
-		Description: "An example prometheus sink",
+		Description: &description,
 		Backend:     "prometheus",
 		ID:          skID.String(),
 		Created:     time.Now(),
@@ -71,7 +72,7 @@ func TestSinkSave(t *testing.T) {
 
 	sinkMalformedOwnerID := sinks.Sink{
 		Name:        nameID,
-		Description: "An example prometheus sink",
+		Description: &description,
 		Backend:     "prometheus",
 		ID:          skID.String(),
 		Created:     time.Now(),
@@ -136,7 +137,7 @@ func TestSinkUpdate(t *testing.T) {
 
 	sink := sinks.Sink{
 		Name:        nameID,
-		Description: "An example prometheus sink",
+		Description: &description,
 		Backend:     "prometheus",
 		Created:     time.Now(),
 		MFOwnerID:   oID.String(),
@@ -153,7 +154,7 @@ func TestSinkUpdate(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 	sinkConflictName := sinks.Sink{
 		Name:        nameConflict,
-		Description: "An example prometheus sink",
+		Description: &description,
 		Backend:     "prometheus",
 		Created:     time.Now(),
 		MFOwnerID:   oID.String(),
@@ -234,7 +235,7 @@ func TestSinkRetrieve(t *testing.T) {
 
 	sink := sinks.Sink{
 		Name:        nameID,
-		Description: "An example prometheus sink",
+		Description: &description,
 		Backend:     "prometheus",
 		Created:     time.Now(),
 		MFOwnerID:   oID.String(),
@@ -288,7 +289,7 @@ func TestMultiSinkRetrieval(t *testing.T) {
 
 		sink := sinks.Sink{
 			Name:        nameID,
-			Description: "An example prometheus sink",
+			Description: &description,
 			Backend:     "prometheus",
 			Created:     time.Now(),
 			MFOwnerID:   oID.String(),
@@ -413,7 +414,7 @@ func TestSinkRemoval(t *testing.T) {
 
 	sink := sinks.Sink{
 		Name:        sinkName,
-		Description: "An example prometheus sink",
+		Description: &description,
 		Backend:     "prometheus",
 		Created:     time.Now(),
 		MFOwnerID:   oID.String(),
@@ -463,7 +464,7 @@ func TestSinkRetrieveInternal(t *testing.T) {
 
 	sink := sinks.Sink{
 		Name:        nameID,
-		Description: "An example prometheus sink",
+		Description: &description,
 		Backend:     "prometheus",
 		Created:     time.Now(),
 		MFOwnerID:   oID.String(),
@@ -528,7 +529,7 @@ func TestUpdateSinkState(t *testing.T) {
 
 	sink := sinks.Sink{
 		Name:        nameID,
-		Description: "An example prometheus sink",
+		Description: &description,
 		Backend:     "prometheus",
 		Created:     time.Now(),
 		MFOwnerID:   oID.String(),

--- a/sinks/sinks.go
+++ b/sinks/sinks.go
@@ -95,7 +95,7 @@ type Sink struct {
 	ID          string
 	Name        types.Identifier
 	MFOwnerID   string
-	Description string
+	Description *string
 	Backend     string
 	Config      types.Metadata
 	Tags        types.Tags

--- a/sinks/sinks_service.go
+++ b/sinks/sinks_service.go
@@ -103,7 +103,7 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 		sink.Tags = currentSink.Tags
 	}
 
-	if sink.Description == "" {
+	if sink.Description == nil {
 		sink.Description = currentSink.Description
 	}
 


### PR DESCRIPTION
- Make it possible to edit tags without any other field being informed in the body, following #2099

- Description:
  - If the description field is omitted, nothing changes
  - If the description field is informed and empty, The description becomes empty (is removed)
  - If the description field is informed and NOT empty, the new description must overwrite the old one

- Fix and add some unit tests