### PR TITLE
[ORB-224] partial updates for datasets

### DIFF
--- a/fleet/comms_test.go
+++ b/fleet/comms_test.go
@@ -626,7 +626,7 @@ func createDataset(t *testing.T, svc policies.Service, name string, groupID stri
 		Name:         validName,
 		PolicyID:     policyID.String(),
 		AgentGroupID: groupID,
-		SinkIDs:      sinkIDs,
+		SinkIDs:      &sinkIDs,
 	}
 
 	res, err := svc.AddDataset(context.Background(), token, dataset)

--- a/policies/api/grpc/endpoint.go
+++ b/policies/api/grpc/endpoint.go
@@ -87,7 +87,7 @@ func retrieveDatasetEnpoint(svc policies.Service) endpoint.Endpoint {
 			id:           dataset.ID,
 			agentGroupID: dataset.AgentGroupID,
 			policyID:     dataset.PolicyID,
-			sinkIDs:      dataset.SinkIDs,
+			sinkIDs:      *dataset.SinkIDs,
 		}, nil
 	}
 }
@@ -108,7 +108,7 @@ func retrieveDatasetsByGroupsEndpoint(svc policies.Service) endpoint.Endpoint {
 			datasets[i] = datasetRes{
 				id:           ds.ID,
 				agentGroupID: ds.AgentGroupID,
-				sinkIDs:      ds.SinkIDs,
+				sinkIDs:      *ds.SinkIDs,
 				policyID:     ds.PolicyID,
 			}
 		}

--- a/policies/api/http/endpoint.go
+++ b/policies/api/http/endpoint.go
@@ -209,7 +209,7 @@ func addDatasetEndpoint(svc policies.Service) endpoint.Endpoint {
 			Name:         nID,
 			AgentGroupID: req.AgentGroupID,
 			PolicyID:     req.PolicyID,
-			SinkIDs:      req.SinkIDs,
+			SinkIDs:      &req.SinkIDs,
 			Tags:         req.Tags,
 		}
 
@@ -224,7 +224,7 @@ func addDatasetEndpoint(svc policies.Service) endpoint.Endpoint {
 			Valid:        saved.Valid,
 			AgentGroupID: saved.AgentGroupID,
 			PolicyID:     saved.PolicyID,
-			SinkIDs:      saved.SinkIDs,
+			SinkIDs:      *saved.SinkIDs,
 			Metadata:     saved.Metadata,
 			TsCreated:    saved.Created,
 			Tags:         saved.Tags,
@@ -268,7 +268,7 @@ func editDatasetEndpoint(svc policies.Service) endpoint.Endpoint {
 			Valid:        ds.Valid,
 			AgentGroupID: ds.AgentGroupID,
 			PolicyID:     ds.PolicyID,
-			SinkIDs:      ds.SinkIDs,
+			SinkIDs:      *ds.SinkIDs,
 			Metadata:     ds.Metadata,
 			TsCreated:    ds.Created,
 			Tags:         ds.Tags,
@@ -348,7 +348,7 @@ func validateDatasetEndpoint(svc policies.Service) endpoint.Endpoint {
 			Name:         nID,
 			AgentGroupID: req.AgentGroupID,
 			PolicyID:     req.PolicyID,
-			SinkIDs:      req.SinkIDs,
+			SinkIDs:      &req.SinkIDs,
 			Tags:         req.Tags,
 		}
 
@@ -363,7 +363,7 @@ func validateDatasetEndpoint(svc policies.Service) endpoint.Endpoint {
 			Tags:         validated.Tags,
 			AgentGroupID: validated.AgentGroupID,
 			PolicyID:     validated.PolicyID,
-			SinkIDs:      validated.SinkIDs,
+			SinkIDs:      *validated.SinkIDs,
 		}
 
 		return res, nil
@@ -386,10 +386,14 @@ func viewDatasetEndpoint(svc policies.Service) endpoint.Endpoint {
 			ID:           dataset.ID,
 			Name:         dataset.Name.String(),
 			PolicyID:     dataset.PolicyID,
-			SinkIDs:      dataset.SinkIDs,
 			AgentGroupID: dataset.AgentGroupID,
 			Valid:        dataset.Valid,
 			TsCreated:    dataset.Created,
+		}
+		if dataset.SinkIDs != nil {
+			res.SinkIDs = *dataset.SinkIDs
+		} else {
+			res.SinkIDs = []string{}
 		}
 		return res, nil
 	}
@@ -422,11 +426,15 @@ func listDatasetEndpoint(svc policies.Service) endpoint.Endpoint {
 				ID:           dataset.ID,
 				Name:         dataset.Name.String(),
 				PolicyID:     dataset.PolicyID,
-				SinkIDs:      dataset.SinkIDs,
 				AgentGroupID: dataset.AgentGroupID,
 				TsCreated:    dataset.Created,
 				Valid:        dataset.Valid,
 				Tags:         dataset.Tags,
+			}
+			if dataset.SinkIDs != nil {
+				view.SinkIDs = *dataset.SinkIDs
+			} else {
+				view.SinkIDs = []string{}
 			}
 			res.Datasets = append(res.Datasets, view)
 		}

--- a/policies/api/http/requests.go
+++ b/policies/api/http/requests.go
@@ -176,7 +176,7 @@ type updateDatasetReq struct {
 	id      string
 	token   string
 	Tags    types.Tags `json:"tags,omitempty"`
-	SinkIDs []string   `json:"sink_ids,omitempty"`
+	SinkIDs *[]string  `json:"sink_ids,omitempty"`
 }
 
 func (req updateDatasetReq) validate() error {
@@ -185,6 +185,10 @@ func (req updateDatasetReq) validate() error {
 	}
 	if req.token == "" {
 		return errors.ErrUnauthorizedAccess
+	}
+
+	if req.Name == "" && req.Tags == nil && req.SinkIDs == nil {
+		return errors.ErrMalformedEntity
 	}
 
 	return nil

--- a/policies/mocks/policies.go
+++ b/policies/mocks/policies.go
@@ -74,7 +74,7 @@ func (m *mockPoliciesRepository) RetrieveAllDatasetsInternal(ctx context.Context
 func (m *mockPoliciesRepository) InactivateDatasetByID(ctx context.Context, sinkID string, ownerID string) error {
 	for _, ds := range m.ddb {
 		if ds.MFOwnerID == ownerID {
-			for _, sID := range ds.SinkIDs {
+			for _, sID := range *ds.SinkIDs {
 				if sID == sinkID {
 					ds.Valid = false
 				}
@@ -89,12 +89,14 @@ func (m *mockPoliciesRepository) DeleteSinkFromAllDatasets(ctx context.Context, 
 
 	for _, ds := range m.ddb {
 		if ds.MFOwnerID == ownerID {
-			for i, sID := range ds.SinkIDs {
+			for i, sID := range *ds.SinkIDs {
 				if sID == sinkID {
-					ds.SinkIDs[i] = ds.SinkIDs[len(ds.SinkIDs)-1]
-					ds.SinkIDs[len(ds.SinkIDs)-1] = ""
-					ds.SinkIDs = ds.SinkIDs[:len(ds.SinkIDs)-1]
+					sinkIDsTemp := *ds.SinkIDs
+					sinkIDsTemp[i] = sinkIDsTemp[len(sinkIDsTemp)-1]
+					sinkIDsTemp[len(sinkIDsTemp)-1] = ""
+					sinkIDsTemp = sinkIDsTemp[:len(sinkIDsTemp)-1]
 
+					ds.SinkIDs = &sinkIDsTemp
 					datasets = append(datasets, ds)
 				}
 			}

--- a/policies/policies.go
+++ b/policies/policies.go
@@ -37,7 +37,7 @@ type Dataset struct {
 	Metadata     types.Metadata
 	Created      time.Time
 	Tags         types.Tags
-	SinkIDs      []string
+	SinkIDs      *[]string
 }
 
 type PolicyInDataset struct {

--- a/policies/policy_service.go
+++ b/policies/policy_service.go
@@ -294,17 +294,26 @@ func (s policiesService) EditDataset(ctx context.Context, token string, ds Datas
 	}
 	ds.MFOwnerID = mfOwnerID
 
-	err = s.validateDatasetSink(ctx, ds.MFOwnerID, ds.SinkIDs)
+	currentDataset, err := s.repo.RetrieveDatasetByID(ctx, ds.ID, ds.MFOwnerID)
 	if err != nil {
 		return Dataset{}, err
 	}
 
 	if ds.Name.String() == "" {
-		currentDataset, err := s.repo.RetrieveDatasetByID(ctx, ds.ID, ds.MFOwnerID)
-		if err != nil {
-			return Dataset{}, err
-		}
 		ds.Name = currentDataset.Name
+	}
+
+	if ds.Tags == nil {
+		ds.Tags = currentDataset.Tags
+	}
+
+	if ds.SinkIDs == nil {
+		ds.SinkIDs = currentDataset.SinkIDs
+	}
+
+	err = s.validateDatasetSink(ctx, ds.MFOwnerID, *ds.SinkIDs)
+	if err != nil {
+		return Dataset{}, err
 	}
 
 	err = s.repo.UpdateDataset(ctx, mfOwnerID, ds)
@@ -351,7 +360,7 @@ func (s policiesService) ValidateDataset(ctx context.Context, token string, d Da
 
 	d.MFOwnerID = mfOwnerID
 
-	err = s.validateDatasetSink(ctx, d.MFOwnerID, d.SinkIDs)
+	err = s.validateDatasetSink(ctx, d.MFOwnerID, *d.SinkIDs)
 	if err != nil {
 		return Dataset{}, err
 	}
@@ -406,12 +415,12 @@ func (s policiesService) InactivateDatasetByIDInternal(ctx context.Context, owne
 func (s policiesService) validateDatasetSink(ctx context.Context, ownerID string, sinkIDs []string) error {
 
 	if len(sinkIDs) == 0 {
-		return errors.Wrap(ErrMalformedEntity, errors.New("empty sink IDs"))
+		return errors.Wrap(errors.ErrMalformedEntity, errors.New("empty sink IDs"))
 	}
 	for _, sinkID := range sinkIDs {
 		_, err := uuid.FromString(sinkID)
 		if err != nil {
-			return errors.Wrap(errors.New("invalid sink id"), ErrMalformedEntity)
+			return errors.Wrap(errors.New("invalid sink id"), errors.ErrMalformedEntity)
 		}
 
 		_, err = s.sinksGrpcClient.RetrieveSink(ctx, &sinkpb.SinkByIDReq{

--- a/policies/postgres/datasets_test.go
+++ b/policies/postgres/datasets_test.go
@@ -55,7 +55,7 @@ func TestDatasetSave(t *testing.T) {
 		Valid:        true,
 		AgentGroupID: groupID.String(),
 		PolicyID:     policyID.String(),
-		SinkIDs:      sinkIDs,
+		SinkIDs:      &sinkIDs,
 		Metadata:     types.Metadata{"testkey": "testvalue"},
 		Created:      time.Time{},
 	}
@@ -86,7 +86,7 @@ func TestDatasetSave(t *testing.T) {
 				Valid:        true,
 				AgentGroupID: groupID.String(),
 				PolicyID:     policyID.String(),
-				SinkIDs:      sinkIDs,
+				SinkIDs:      &sinkIDs,
 			},
 			err: errors.ErrMalformedEntity,
 		},
@@ -132,7 +132,7 @@ func TestDatasetUpdate(t *testing.T) {
 		Valid:        true,
 		AgentGroupID: groupID.String(),
 		PolicyID:     policyID.String(),
-		SinkIDs:      sinkIDs,
+		SinkIDs:      &sinkIDs,
 		Metadata:     types.Metadata{"testkey": "testvalue"},
 		Created:      time.Time{},
 	}
@@ -157,7 +157,7 @@ func TestDatasetUpdate(t *testing.T) {
 				Valid:        true,
 				AgentGroupID: groupID.String(),
 				PolicyID:     policyID.String(),
-				SinkIDs:      sinkIDs,
+				SinkIDs:      &sinkIDs,
 				Metadata:     types.Metadata{"testkey": "testvalue"},
 				Created:      time.Time{},
 				ID:           wrongID.String(),
@@ -206,7 +206,7 @@ func TestDatasetDelete(t *testing.T) {
 		Valid:        true,
 		AgentGroupID: groupID.String(),
 		PolicyID:     policyID.String(),
-		SinkIDs:      sinkIDs,
+		SinkIDs:      &sinkIDs,
 		Metadata:     types.Metadata{"testkey": "testvalue"},
 		Created:      time.Time{},
 	}
@@ -270,7 +270,7 @@ func TestDatasetRetrieveByID(t *testing.T) {
 		Valid:        true,
 		AgentGroupID: groupID.String(),
 		PolicyID:     policyID.String(),
-		SinkIDs:      sinkIDs,
+		SinkIDs:      &sinkIDs,
 		Metadata:     types.Metadata{"testkey": "testvalue"},
 		Created:      time.Time{},
 	}
@@ -456,7 +456,7 @@ func TestInactivateDatasetByGroupID(t *testing.T) {
 		Valid:        true,
 		AgentGroupID: groupID.String(),
 		PolicyID:     policyID.String(),
-		SinkIDs:      sinkIDs,
+		SinkIDs:      &sinkIDs,
 		Metadata:     types.Metadata{"testkey": "testvalue"},
 		Created:      time.Time{},
 	}
@@ -525,7 +525,7 @@ func TestInactivateDatasetByPolicyID(t *testing.T) {
 		Valid:        true,
 		AgentGroupID: groupID.String(),
 		PolicyID:     policyID.String(),
-		SinkIDs:      sinkIDs,
+		SinkIDs:      &sinkIDs,
 		Metadata:     types.Metadata{"testkey": "testvalue"},
 		Created:      time.Time{},
 	}
@@ -660,7 +660,7 @@ func TestInactivateDatasetByID(t *testing.T) {
 		Valid:        true,
 		AgentGroupID: groupID.String(),
 		PolicyID:     policyID.String(),
-		SinkIDs:      sinkIDs,
+		SinkIDs:      &sinkIDs,
 		Metadata:     types.Metadata{"testkey": "testvalue"},
 		Created:      time.Time{},
 	}
@@ -751,10 +751,12 @@ func TestDeleteSinkFromDataset(t *testing.T) {
 		Valid:        true,
 		AgentGroupID: groupID.String(),
 		PolicyID:     policyID.String(),
-		SinkIDs:      sinkIDs,
+		SinkIDs:      &sinkIDs,
 		Metadata:     types.Metadata{"testkey": "testvalue"},
 		Created:      time.Time{},
 	}
+
+	deleteSinkArray := []string{sinkIDs[0]}
 
 	dataset2 := dataset
 	dataset2.Name = nameID2
@@ -779,7 +781,7 @@ func TestDeleteSinkFromDataset(t *testing.T) {
 	}{
 		"delete a sink from existing dataset": {
 			owner:    dataset.MFOwnerID,
-			sinkID:   dataset.SinkIDs[0],
+			sinkID:   deleteSinkArray[0],
 			contains: false,
 			dataset:  dataset,
 			err:      nil,
@@ -792,7 +794,7 @@ func TestDeleteSinkFromDataset(t *testing.T) {
 			err:      nil,
 		},
 		"delete a sink from a dataset with an invalid ownerID": {
-			sinkID:   dataset2.SinkIDs[0],
+			sinkID:   deleteSinkArray[0],
 			owner:    "",
 			contains: true,
 			dataset:  dataset2,
@@ -808,9 +810,9 @@ func TestDeleteSinkFromDataset(t *testing.T) {
 			for _, d := range dataset {
 				switch tc.contains {
 				case false:
-					assert.NotContains(t, d.SinkIDs, tc.sinkID, fmt.Sprintf("%s: expected '%s' to not contains '%s'", desc, d.SinkIDs, tc.sinkID))
+					assert.NotContains(t, *d.SinkIDs, tc.sinkID, fmt.Sprintf("%s: expected '%p' to not contains '%s'", desc, d.SinkIDs, tc.sinkID))
 				case true:
-					assert.Contains(t, d.SinkIDs, tc.sinkID, fmt.Sprintf("%s: expected '%s' to contains '%s'", desc, d.SinkIDs, tc.sinkID))
+					assert.Contains(t, *d.SinkIDs, tc.sinkID, fmt.Sprintf("%s: expected '%p' to contains '%s'", desc, d.SinkIDs, tc.sinkID))
 				}
 			}
 		})
@@ -852,7 +854,7 @@ func TestActivateDatasetByID(t *testing.T) {
 		Valid:        false,
 		AgentGroupID: groupID.String(),
 		PolicyID:     policyID.String(),
-		SinkIDs:      sinkIDs,
+		SinkIDs:      &sinkIDs,
 		Metadata:     types.Metadata{"testkey": "testvalue"},
 		Created:      time.Time{},
 	}
@@ -943,7 +945,7 @@ func TestDeleteAgentGroupFromDataset(t *testing.T) {
 		Valid:        true,
 		AgentGroupID: groupID.String(),
 		PolicyID:     policyID.String(),
-		SinkIDs:      sinkIDs,
+		SinkIDs:      &sinkIDs,
 		Metadata:     types.Metadata{"testkey": "testvalue"},
 		Created:      time.Time{},
 	}
@@ -1042,7 +1044,7 @@ func TestDeleteAllDatasetsPolicy(t *testing.T) {
 		Valid:        true,
 		AgentGroupID: groupID.String(),
 		PolicyID:     policyID.String(),
-		SinkIDs:      sinkIDs,
+		SinkIDs:      &sinkIDs,
 		Metadata:     types.Metadata{"testkey": "testvalue"},
 		Created:      time.Time{},
 	}
@@ -1125,7 +1127,7 @@ func TestDatasetsRetrieveByGroup(t *testing.T) {
 		Valid:        true,
 		AgentGroupID: groupID.String(),
 		PolicyID:     policyID,
-		SinkIDs:      sinkIDs,
+		SinkIDs:      &sinkIDs,
 		Metadata:     types.Metadata{"testkey": "testvalue"},
 		Created:      time.Time{},
 	}

--- a/policies/postgres/policies.go
+++ b/policies/postgres/policies.go
@@ -826,11 +826,15 @@ func toDataset(dba dbDataset) policies.Dataset {
 		Valid:        dba.Valid,
 		AgentGroupID: dba.AgentGroupID.String,
 		PolicyID:     dba.PolicyID.String,
-		SinkIDs:      dba.SinkIDs,
+		SinkIDs:      (*[]string)(&dba.SinkIDs),
 		Metadata:     types.Metadata(dba.Metadata),
 		Created:      dba.TsCreated,
 		Tags:         types.Tags(dba.Tags),
 	}
+
+	//var sinkIDs []string
+	//sinkIDs = dba.SinkIDs
+	//dataset.SinkIDs = &sinkIDs
 
 	return dataset
 }

--- a/policies/postgres/policies_test.go
+++ b/policies/postgres/policies_test.go
@@ -300,7 +300,7 @@ func TestAgentPoliciesRetrieveByGroup(t *testing.T) {
 		Valid:        true,
 		AgentGroupID: groupID.String(),
 		PolicyID:     policyID,
-		SinkIDs:      sinkIDs,
+		SinkIDs:      &sinkIDs,
 		Metadata:     types.Metadata{"testkey": "testvalue"},
 		Created:      time.Time{},
 	}

--- a/policies/redis/consumer/streams.go
+++ b/policies/redis/consumer/streams.go
@@ -158,7 +158,7 @@ func (es eventStore) handleSinkRemove(ctx context.Context, sinkID string, ownerI
 	}
 
 	for _, ds := range datasets {
-		if len(ds.SinkIDs) == 0 {
+		if len(*ds.SinkIDs) == 0 {
 			err = es.policiesService.InactivateDatasetByIDInternal(ctx, ownerID, ds.ID)
 			if err != nil {
 				return err

--- a/policies/redis/producer/streams.go
+++ b/policies/redis/producer/streams.go
@@ -247,7 +247,7 @@ func (e eventStore) AddDataset(ctx context.Context, token string, d policies.Dat
 		name:         ds.Name.String(),
 		agentGroupID: ds.AgentGroupID,
 		policyID:     ds.PolicyID,
-		sinkIDs:      strings.Join(ds.SinkIDs, ","),
+		sinkIDs:      strings.Join(*ds.SinkIDs, ","),
 	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,


### PR DESCRIPTION
Support updates on datasets API to name and sinks ids without requiring the other fields to be provided in the JSON body:

Both cases follow the rules:

- If it is informed, the new one must overwrite the old one
- If it is omitted, the old one must be maintained.
- If it is informed with empty or invalid values, an error must be raised informing that the attribute doesn't match the pattern required.